### PR TITLE
Add stream buffer policy and related settings.

### DIFF
--- a/app/kvsapp/include/kvs/kvsapp.h
+++ b/app/kvsapp/include/kvs/kvsapp.h
@@ -79,13 +79,7 @@ int KvsApp_close(KvsAppHandle handle);
  * @param[in] xTrackType Track type, it could be TRACK_VIDEO or TRACK_AUDIO
  * @return 0 on success, non-zero value otherwise
  */
-int KvsApp_addFrame(
-    KvsAppHandle handle,
-    uint8_t *pData,
-    size_t uDataLen,
-    size_t uDataSize,
-    uint64_t uTimestamp,
-    TrackType_t xTrackType);
+int KvsApp_addFrame(KvsAppHandle handle, uint8_t *pData, size_t uDataLen, size_t uDataSize, uint64_t uTimestamp, TrackType_t xTrackType);
 
 /**
  * Let KVS application do works. It will try to send out frames, and check if any messages from server.
@@ -95,4 +89,12 @@ int KvsApp_addFrame(
  */
 int KvsApp_doWork(KvsAppHandle handle);
 
-#endif
+/**
+ * Get the memory used in the stream buffer.
+ *
+ * @param handle  KVS application handle
+ * @return Memory used in current stream buffer, zero value otherwise
+ */
+size_t KvsApp_getStreamMemStatTotal(KvsAppHandle handle);
+
+#endif /* KVSAPP_H */

--- a/app/kvsapp/include/kvs/kvsapp_options.h
+++ b/app/kvsapp/include/kvs/kvsapp_options.h
@@ -16,6 +16,13 @@
 #ifndef KVSAPP_OPTIONS_H
 #define KVSAPP_OPTIONS_H
 
+typedef enum KvsApp_streamPolicy
+{
+    STREAM_POLICY_NONE = 0,
+    STREAM_POLICY_RING_BUFFER,
+    STREAM_POLICY_MAX
+} KvsApp_streamPolicy_t;
+
 static const char * const OPTION_AWS_ACCESS_KEY_ID = "Aws_accessKeyId";
 static const char * const OPTION_AWS_SECRET_ACCESS_KEY = "Aws_secretAccessKey";
 
@@ -29,5 +36,9 @@ static const char * const OPTION_IOT_X509_KEY = "Iot_x509PrivateKey";
 static const char * const OPTION_KVS_DATA_RETENTION_IN_HOURS = "Kvs_dataRetentionInHours";
 static const char * const OPTION_KVS_VIDEO_TRACK_INFO = "Kvs_videoTrackInfo";
 static const char * const OPTION_KVS_AUDIO_TRACK_INFO = "Kvs_audioTrackInfo";
+
+static const char * const OPTION_STREAM_POLICY = "Stream_policy";
+
+static const char * const OPTION_STREAM_POLICY_RING_BUFFER_MEM_LIMIT = "Stream_RbMemlimit";
 
 #endif

--- a/samples/kvsapp-ingenic-t31/include/sample_config.h
+++ b/samples/kvsapp-ingenic-t31/include/sample_config.h
@@ -40,7 +40,7 @@
 #define AUDIO_CODEC_NAME                "A_AAC"
 #define AUDIO_TRACK_NAME                "kvs audio track"
 #define AUDIO_MPEG_OBJECT_TYPE          AAC_LC
-#define AUDIO_FREQUENCY                 48000
+#define AUDIO_FREQUENCY                 16000
 #define AUDIO_CHANNEL_NUMBER            2
 #endif /* ENABLE_AUDIO_TRACK */
 
@@ -65,5 +65,8 @@
 "......\n" \
 "-----END RSA PRIVATE KEY-----\n"
 #endif
+
+/* Buffering options */
+#define RING_BUFFER_MEM_LIMIT (2 * 1000 * 1000)
 
 #endif /* SAMPLE_CONFIG_H */

--- a/samples/kvsapp-ingenic-t31/source/kvsappcli.c
+++ b/samples/kvsapp-ingenic-t31/source/kvsappcli.c
@@ -90,12 +90,24 @@ static int setKvsAppOptions(KvsAppHandle kvsAppHandle)
     }
 #endif /* ENABLE_AUDIO_TRACK */
 
+    KvsApp_streamPolicy_t xPolicy = STREAM_POLICY_RING_BUFFER;
+    if (KvsApp_setoption(kvsAppHandle, OPTION_STREAM_POLICY, (const char *)&xPolicy) != 0)
+    {
+        printf("Failed to set stream policy\r\n");
+    }
+    size_t uRingBufferMemLimit = RING_BUFFER_MEM_LIMIT;
+    if (KvsApp_setoption(kvsAppHandle, OPTION_STREAM_POLICY_RING_BUFFER_MEM_LIMIT, (const char *)&uRingBufferMemLimit) != 0)
+    {
+        printf("Failed to set ring buffer memory limit\r\n");
+    }
+
     return res;
 }
 
 int main(int argc, char *argv[])
 {
     KvsAppHandle kvsAppHandle;
+    uint64_t uLastPrintMemStatTimestamp = 0;
 
     if ((kvsAppHandle = KvsApp_create(AWS_KVS_HOST, AWS_KVS_REGION, AWS_KVS_SERVICE, KVS_STREAM_NAME)) == NULL)
     {
@@ -130,6 +142,12 @@ int main(int argc, char *argv[])
                 if (KvsApp_doWork(kvsAppHandle) != 0)
                 {
                     break;
+                }
+
+                if (getEpochTimestampInMs() > uLastPrintMemStatTimestamp + 1000)
+                {
+                    printf("Buffer memory used: %zu\r\n", KvsApp_getStreamMemStatTotal(kvsAppHandle));
+                    uLastPrintMemStatTimestamp = getEpochTimestampInMs();
                 }
             }
 


### PR DESCRIPTION
Add stream buffer policy. There is only 2 policy now.

The first one is policy none which do nothing when buffer.

The second one is ring buffer policy.  It will remove earliest frames when total memory of the buffer exceed the limit.
Application can set this policy and memory limit by using options.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
