### PR TITLE
ring buffer: introduce ENABLE_RING_BUFFER_MEM_LIMIT into sample config

### DIFF
--- a/samples/kvsapp-ingenic-t31/include/sample_config.h
+++ b/samples/kvsapp-ingenic-t31/include/sample_config.h
@@ -31,6 +31,7 @@
 /* KVS optional configuration */
 #define ENABLE_AUDIO_TRACK              1
 #define ENABLE_IOT_CREDENTIAL           0
+#define ENABLE_RING_BUFFER_MEM_LIMIT    1
 
 #define VIDEO_CODEC_NAME                "V_MPEG4/ISO/AVC"
 #define VIDEO_TRACK_NAME                "kvs video track"
@@ -66,7 +67,9 @@
 "-----END RSA PRIVATE KEY-----\n"
 #endif
 
+#if ENABLE_RING_BUFFER_MEM_LIMIT
 /* Buffering options */
-#define RING_BUFFER_MEM_LIMIT (2 * 1000 * 1000)
+#define RING_BUFFER_MEM_LIMIT           (2 * 1024 * 1024)
+#endif /* ENABLE_RING_BUFFER_MEM_LIMIT */
 
 #endif /* SAMPLE_CONFIG_H */

--- a/samples/kvsapp-ingenic-t31/source/kvsappcli.c
+++ b/samples/kvsapp-ingenic-t31/source/kvsappcli.c
@@ -90,6 +90,7 @@ static int setKvsAppOptions(KvsAppHandle kvsAppHandle)
     }
 #endif /* ENABLE_AUDIO_TRACK */
 
+#if ENABLE_RING_BUFFER_MEM_LIMIT
     KvsApp_streamPolicy_t xPolicy = STREAM_POLICY_RING_BUFFER;
     if (KvsApp_setoption(kvsAppHandle, OPTION_STREAM_POLICY, (const char *)&xPolicy) != 0)
     {
@@ -100,6 +101,7 @@ static int setKvsAppOptions(KvsAppHandle kvsAppHandle)
     {
         printf("Failed to set ring buffer memory limit\r\n");
     }
+#endif /* ENABLE_RING_BUFFER_MEM_LIMIT */
 
     return res;
 }

--- a/samples/kvsapp/kvsappcli.c
+++ b/samples/kvsapp/kvsappcli.c
@@ -174,6 +174,19 @@ static int setKvsAppOptions(KvsAppHandle kvsAppHandle)
     }
 #endif /* ENABLE_AUDIO_TRACK */
 
+#if ENABLE_RING_BUFFER_MEM_LIMIT
+    KvsApp_streamPolicy_t xPolicy = STREAM_POLICY_RING_BUFFER;
+    if (KvsApp_setoption(kvsAppHandle, OPTION_STREAM_POLICY, (const char *)&xPolicy) != 0)
+    {
+        printf("Failed to set stream policy\r\n");
+    }
+    size_t uRingBufferMemLimit = RING_BUFFER_MEM_LIMIT;
+    if (KvsApp_setoption(kvsAppHandle, OPTION_STREAM_POLICY_RING_BUFFER_MEM_LIMIT, (const char *)&uRingBufferMemLimit) != 0)
+    {
+        printf("Failed to set ring buffer memory limit\r\n");
+    }
+#endif /* ENABLE_RING_BUFFER_MEM_LIMIT */
+
     return res;
 }
 

--- a/samples/kvsapp/sample_config.h
+++ b/samples/kvsapp/sample_config.h
@@ -31,6 +31,7 @@
 /* KVS optional configuration */
 #define ENABLE_AUDIO_TRACK              1
 #define ENABLE_IOT_CREDENTIAL           0
+#define ENABLE_RING_BUFFER_MEM_LIMIT    1
 
 /* Video configuration */
 #define H264_FILE_FORMAT                "/path/to/samples/h264SampleFrames/frame-%03d.h264"
@@ -74,5 +75,10 @@
 "......\n" \
 "-----END RSA PRIVATE KEY-----\n"
 #endif
+
+#if ENABLE_RING_BUFFER_MEM_LIMIT
+/* Buffering options */
+#define RING_BUFFER_MEM_LIMIT           (2 * 1024 * 1024)
+#endif /* ENABLE_RING_BUFFER_MEM_LIMIT */
 
 #endif /* SAMPLE_CONFIG_H */


### PR DESCRIPTION
Signed-off-by: Alex.Li <zhiqinli@amazon.com>

*Issue #, if available:*

*Description of changes:*
This change will add an option in sample config to set ring buffer size limitation. This change will add missing ringbuf limits handling in kvsapp as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
