### PR TITLE
Change default data retention in hours

### DIFF
--- a/app/kvsapp/source/kvsapp.c
+++ b/app/kvsapp/source/kvsapp.c
@@ -39,6 +39,7 @@
 #define VIDEO_CODEC_NAME "V_MPEG4/ISO/AVC"
 #define VIDEO_TRACK_NAME "kvs video track"
 
+#define DEFAULT_DATA_RETENTION_IN_HOURS (2)
 #define DEFAULT_RING_BUFFER_MEM_LIMIT (1 * 1024 * 1024)
 
 typedef struct PolicyRingBufferParameter
@@ -676,7 +677,7 @@ KvsAppHandle KvsApp_create(char *pcHost, char *pcRegion, char *pcService, char *
             pKvs->pIotX509PrivateKey = NULL;
             pKvs->pToken = NULL;
 
-            pKvs->uDataRetentionInHours = 0;
+            pKvs->uDataRetentionInHours = DEFAULT_DATA_RETENTION_IN_HOURS;
 
             pKvs->uEarliestTimestamp = 0;
             pKvs->xStreamHandle = NULL;


### PR DESCRIPTION
Modify origin default value 0 to 2 hours.

User can change this setting by following sample code.

```
unsigned int uDataRetentionInHours = 24;
KvsApp_setoption(kvsAppHandle, OPTION_KVS_DATA_RETENTION_IN_HOURS, (const char *)&uDataRetentionInHours);
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
