### PR TITLE
Add API to get memory statistics

### DIFF
--- a/samples/kvsapp-ingenic-t31/include/sample_config.h
+++ b/samples/kvsapp-ingenic-t31/include/sample_config.h
@@ -73,7 +73,31 @@
 #endif /* ENABLE_RING_BUFFER_MEM_LIMIT */
 
 #ifdef KVS_USE_POOL_ALLOCATOR
-#define POOL_ALLOCATOR_SIZE             (2 * 1024 * 1024 + 512 * 1024)
+
+/**
+ * KVS LIB and its 3rd party dependencies use 48K bytes which is measured on RPi. Make it 128K for safety.
+ */
+#define POOL_ALLOCATOR_SIZE_FOR_KVS     (128 * 1024)
+
+/**
+ * This sample use 1M measured on T31. Make it 1.5M for safety. Please increase it depends on real application.
+ */
+#define POOL_ALLOCATOR_SIZE_FOR_APP     (1536 * 1024)
+
+/**
+ * Get the size of stream buffer.  If there is no buffer limit, then assume it's 2M bytes.
+ */
+#ifdef ENABLE_RING_BUFFER_MEM_LIMIT
+#define BUFFER_MEM_LIMIT        RING_BUFFER_MEM_LIMIT
+#else
+#define BUFFER_MEM_LIMIT        (2 * 1024 * 1024)
 #endif
+
+/**
+ * Total size for pool equals the sum of KVS and its libraries usage, the stream buffer usage, and application usage.
+ */
+#define POOL_ALLOCATOR_SIZE     (BUFFER_MEM_LIMIT + POOL_ALLOCATOR_SIZE_FOR_KVS + POOL_ALLOCATOR_SIZE_FOR_APP)
+
+#endif /* KVS_USE_POOL_ALLOCATOR */
 
 #endif /* SAMPLE_CONFIG_H */

--- a/samples/kvsapp-ingenic-t31/source/kvsappcli.c
+++ b/samples/kvsapp-ingenic-t31/source/kvsappcli.c
@@ -25,7 +25,7 @@
 #include "sample_config.h"
 #include "t31_video.h"
 #if ENABLE_AUDIO_TRACK
-#    include "t31_audio.h"
+#include "t31_audio.h"
 #endif /* ENABLE_AUDIO_TRACK */
 
 #define ERRNO_NONE 0
@@ -159,6 +159,16 @@ int main(int argc, char *argv[])
                 {
                     printf("Buffer memory used: %zu\r\n", KvsApp_getStreamMemStatTotal(kvsAppHandle));
                     uLastPrintMemStatTimestamp = getEpochTimestampInMs();
+
+#ifdef KVS_USE_POOL_ALLOCATOR
+                    PoolStats_t stats = {0};
+                    poolAllocatorGetStats(&stats);
+                    printf("Sum of used/free memory:%zu/%zu, size of larget used/free block:%zu/%zu, number of used/free blocks:%zu/%zu\n",
+                        stats.uSumOfUsedMemory, stats.uSumOfFreeMemory,
+                        stats.uSizeOfLargestUsedBlock, stats.uSizeOfLargestFreeBlock,
+                        stats.uNumberOfUsedBlocks, stats.uNumberOfFreeBlocks
+                    );
+#endif
                 }
             }
 

--- a/samples/kvsapp-ingenic-t31/source/t31_video.c
+++ b/samples/kvsapp-ingenic-t31/source/t31_video.c
@@ -112,7 +112,7 @@ static int sendVideoFrame(T31Video_t *pVideo, IMPEncoderStream *pStream)
 
         if ((pPacketBuf = (uint8_t *)malloc(uPacketLen)) == NULL)
         {
-            printf("%s(): OOM: pPacketBuf\n", __FUNCTION__);
+            printf("%s(): OOM: pPacketBuf, size:%zu\n", __FUNCTION__, uPacketLen);
             res = ERRNO_FAIL;
         }
         else

--- a/samples/kvsapp/kvsappcli.c
+++ b/samples/kvsapp/kvsappcli.c
@@ -27,7 +27,7 @@
 #include "sample_config.h"
 
 #if ENABLE_AUDIO_TRACK
-#    include "aac_file_loader.h"
+#include "aac_file_loader.h"
 #endif /* ENABLE_AUDIO_TRACK */
 
 #define ERRNO_NONE 0
@@ -201,6 +201,7 @@ int main(int argc, char *argv[])
     KvsAppHandle kvsAppHandle;
     FileLoaderPara_t xVideoFileLoaderParam = {0};
     FileLoaderPara_t xAudioFileLoaderParam = {0};
+    uint64_t uLastPrintMemStatTimestamp = 0;
 
 #ifdef KVS_USE_POOL_ALLOCATOR
     poolAllocatorInit((void *)pMemPool, sizeof(pMemPool));
@@ -263,6 +264,21 @@ int main(int argc, char *argv[])
                 if (KvsApp_doWork(kvsAppHandle) != 0)
                 {
                     break;
+                }
+
+                if (getEpochTimestampInMs() > uLastPrintMemStatTimestamp + 1000)
+                {
+                    printf("Buffer memory used: %zu\r\n", KvsApp_getStreamMemStatTotal(kvsAppHandle));
+                    uLastPrintMemStatTimestamp = getEpochTimestampInMs();
+#ifdef KVS_USE_POOL_ALLOCATOR
+                    PoolStats_t stats = {0};
+                    poolAllocatorGetStats(&stats);
+                    printf("Sum of used/free memory:%zu/%zu, size of larget used/free block:%zu/%zu, number of used/free blocks:%zu/%zu\n",
+                        stats.uSumOfUsedMemory, stats.uSumOfFreeMemory,
+                        stats.uSizeOfLargestUsedBlock, stats.uSizeOfLargestFreeBlock,
+                        stats.uNumberOfUsedBlocks, stats.uNumberOfFreeBlocks
+                    );
+#endif
                 }
             }
 

--- a/samples/kvsapp/sample_config.h
+++ b/samples/kvsapp/sample_config.h
@@ -82,7 +82,31 @@
 #endif /* ENABLE_RING_BUFFER_MEM_LIMIT */
 
 #ifdef KVS_USE_POOL_ALLOCATOR
-#define POOL_ALLOCATOR_SIZE             (2 * 1024 * 1024 + 512 * 1024)
+
+/**
+ * KVS LIB and its 3rd party dependencies use 48K bytes which is measured on RPi. Make it 128K for safety.
+ */
+#define POOL_ALLOCATOR_SIZE_FOR_KVS     (128 * 1024)
+
+/**
+ * Reserve 512K for application usage.
+ */
+#define POOL_ALLOCATOR_SIZE_FOR_APP     (512 * 1024)
+
+/**
+ * Get the size of stream buffer.  If there is no buffer limit, then assume it's 2M bytes.
+ */
+#ifdef ENABLE_RING_BUFFER_MEM_LIMIT
+#define BUFFER_MEM_LIMIT        RING_BUFFER_MEM_LIMIT
+#else
+#define BUFFER_MEM_LIMIT        (2 * 1024 * 1024)
 #endif
+
+/**
+ * Total size for pool equals the sum of KVS and its libraries usage, the stream buffer usage, and application usage.
+ */
+#define POOL_ALLOCATOR_SIZE     (BUFFER_MEM_LIMIT + POOL_ALLOCATOR_SIZE_FOR_KVS + POOL_ALLOCATOR_SIZE_FOR_APP)
+
+#endif /* KVS_USE_POOL_ALLOCATOR */
 
 #endif /* SAMPLE_CONFIG_H */

--- a/src/include/kvs/pool_allocator.h
+++ b/src/include/kvs/pool_allocator.h
@@ -18,6 +18,16 @@
 
 #include <stddef.h>
 
+typedef struct PoolStats
+{
+    size_t uNumberOfUsedBlocks;
+    size_t uNumberOfFreeBlocks;
+    size_t uSumOfUsedMemory;
+    size_t uSumOfFreeMemory;
+    size_t uSizeOfLargestUsedBlock;
+    size_t uSizeOfLargestFreeBlock;
+} PoolStats_t;
+
 /**
  * Init pool allocator with specified size. The pool is allocated from default malloc.
  *
@@ -38,8 +48,8 @@ void *poolAllocatorMalloc(size_t bytes);
 /**
  * Re-allocate memory from memory pool. If pool allocator hasn't been initialized, then it'll be initialized here with default size.
  *
- * @param ptr Pointer to be re-allocate
- * @param bytes New memory size
+ * @param[in] ptr Pointer to be re-allocate
+ * @param[in] bytes New memory size
  * @return Newly allocated memory on success, NULL otherwise
  */
 void *poolAllocatorRealloc(void *ptr, size_t bytes);
@@ -47,8 +57,8 @@ void *poolAllocatorRealloc(void *ptr, size_t bytes);
 /**
  * Allocate and clear memory from memory pool. If pool allocator hasn't been initialized, then it'll be initialized here with default size.
  *
- * @param num Number of elements
- * @param bytes Element size
+ * @param[in] num Number of elements
+ * @param[in] bytes Element size
  * @return Newly allocated memory on success, NULL otherwise
  */
 void *poolAllocatorCalloc(size_t num, size_t bytes);
@@ -56,7 +66,7 @@ void *poolAllocatorCalloc(size_t num, size_t bytes);
 /**
  * Free memory from memory pool.
  *
- * @param ptr Pointer to be freed
+ * @param[in] ptr Pointer to be freed
  */
 void poolAllocatorFree(void *ptr);
 
@@ -64,5 +74,12 @@ void poolAllocatorFree(void *ptr);
  * Deinit pool allocator.
  */
 void poolAllocatorDeinit(void);
+
+/**
+ * Get statistics of pool allocator.
+ *
+ * @param[in] pPoolStats Pool statistics
+ */
+void poolAllocatorGetStats(PoolStats_t *pPoolStats);
 
 #endif /* POOL_ALLOCATOR_H */

--- a/src/source/stream.c
+++ b/src/source/stream.c
@@ -234,7 +234,7 @@ DataFrameHandle Kvs_streamAddDataFrame(StreamHandle xStreamHandle, DataFrameIn_t
         {
             pxDataFrameCurrent = containingRecord(pxListItem, DataFrame_t, xDataFrameEntry);
             if (pxDataFrame->xDataFrameIn.uTimestampMs < pxDataFrameCurrent->xDataFrameIn.uTimestampMs ||
-                pxDataFrame->xDataFrameIn.uTimestampMs == pxDataFrameCurrent->xDataFrameIn.uTimestampMs && pxDataFrame->xDataFrameIn.xTrackType == TRACK_VIDEO)
+                ((pxDataFrame->xDataFrameIn.uTimestampMs == pxDataFrameCurrent->xDataFrameIn.uTimestampMs) && (pxDataFrame->xDataFrameIn.xTrackType == TRACK_VIDEO)))
             {
                 DList_InsertTailList(pxListItem, &(pxDataFrame->xDataFrameEntry));
                 uDeltaTimestampMs = (uint16_t)(pxDataFrame->xDataFrameIn.uTimestampMs - uClusterTimestamp);
@@ -455,3 +455,4 @@ void Kvs_dataFrameTerminate(DataFrameHandle xDataFrameHandle)
         kvsFree(pxDataFrame);
     }
 }
+


### PR DESCRIPTION
*   Add API to get memory statistics.
*   Fix bug in option OPTION_STREAM_POLICY_RING_BUFFER_MEM_LIMIT that it applies wrong value.
*   Adjust memory limits for T31
*   Fix stall when doing stream flush and there is no frame available.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
