### PR TITLE
Change default network I/O from blocking to non-blocking

### DIFF
--- a/app/kvsapp/include/kvs/kvsapp_options.h
+++ b/app/kvsapp/include/kvs/kvsapp_options.h
@@ -38,7 +38,10 @@ static const char * const OPTION_KVS_VIDEO_TRACK_INFO = "Kvs_videoTrackInfo";
 static const char * const OPTION_KVS_AUDIO_TRACK_INFO = "Kvs_audioTrackInfo";
 
 static const char * const OPTION_STREAM_POLICY = "Stream_policy";
-
 static const char * const OPTION_STREAM_POLICY_RING_BUFFER_MEM_LIMIT = "Stream_RbMemlimit";
+
+static const char * const OPTION_NETIO_CONNECTION_TIMEOUT = "NetIo_connTimeout";
+static const char * const OPTION_NETIO_STREAMING_RECV_TIMEOUT = "NetIo_recvTimeout";
+static const char * const OPTION_NETIO_STREAMING_SEND_TIMEOUT = "NetIo_sendTimeout";
 
 #endif

--- a/app/kvsapp/source/kvsapp.c
+++ b/app/kvsapp/source/kvsapp.c
@@ -38,7 +38,10 @@
 #define VIDEO_CODEC_NAME "V_MPEG4/ISO/AVC"
 #define VIDEO_TRACK_NAME "kvs video track"
 
+#define DEFAULT_CONNECTION_TIMEOUT_MS (10 * 1000)
 #define DEFAULT_DATA_RETENTION_IN_HOURS (2)
+#define DEFAULT_PUT_MEDIA_RECV_TIMEOUT_MS (1 * 1000)
+#define DEFAULT_PUT_MEDIA_SEND_TIMEOUT_MS (1 * 1000)
 #define DEFAULT_RING_BUFFER_MEM_LIMIT (1 * 1024 * 1024)
 
 typedef struct PolicyRingBufferParameter
@@ -372,6 +375,8 @@ static int updateAndVerifyRestfulReqParameters(KvsApp_t *pKvs)
     pKvs->xServicePara.pcHost = pKvs->pHost;
     pKvs->xServicePara.pcRegion = pKvs->pRegion;
     pKvs->xServicePara.pcService = pKvs->pService;
+    pKvs->xServicePara.uRecvTimeoutMs = DEFAULT_CONNECTION_TIMEOUT_MS;
+    pKvs->xServicePara.uSendTimeoutMs = DEFAULT_CONNECTION_TIMEOUT_MS;
 
     if (pKvs->pToken != NULL)
     {
@@ -405,6 +410,8 @@ static int updateAndVerifyRestfulReqParameters(KvsApp_t *pKvs)
 
         pKvs->xPutMediaPara.pcStreamName = pKvs->pStreamName;
         pKvs->xPutMediaPara.xTimecodeType = TIMECODE_TYPE_ABSOLUTE;
+        pKvs->xPutMediaPara.uRecvTimeoutMs = DEFAULT_PUT_MEDIA_RECV_TIMEOUT_MS;
+        pKvs->xPutMediaPara.uSendTimeoutMs = DEFAULT_PUT_MEDIA_SEND_TIMEOUT_MS;
     }
 
     return res;
@@ -805,7 +812,7 @@ int KvsApp_setoption(KvsAppHandle handle, const char *pcOptionName, const char *
     }
     else
     {
-        if (strcmp(pcOptionName, OPTION_AWS_ACCESS_KEY_ID) == 0)
+        if (strncmp(pcOptionName, (const char *)OPTION_AWS_ACCESS_KEY_ID, sizeof(OPTION_AWS_ACCESS_KEY_ID)) == 0)
         {
             if (mallocAndStrcpy_s(&(pKvs->pAwsAccessKeyId), pValue) != 0)
             {
@@ -813,7 +820,7 @@ int KvsApp_setoption(KvsAppHandle handle, const char *pcOptionName, const char *
                 res = ERRNO_FAIL;
             }
         }
-        else if (strcmp(pcOptionName, OPTION_AWS_SECRET_ACCESS_KEY) == 0)
+        else if (strncmp(pcOptionName, (const char *)OPTION_AWS_SECRET_ACCESS_KEY, sizeof(OPTION_AWS_SECRET_ACCESS_KEY)) == 0)
         {
             if (mallocAndStrcpy_s(&(pKvs->pAwsSecretAccessKey), pValue) != 0)
             {
@@ -821,7 +828,7 @@ int KvsApp_setoption(KvsAppHandle handle, const char *pcOptionName, const char *
                 res = ERRNO_FAIL;
             }
         }
-        else if (strcmp(pcOptionName, OPTION_IOT_CREDENTIAL_HOST) == 0)
+        else if (strncmp(pcOptionName, (const char *)OPTION_IOT_CREDENTIAL_HOST, sizeof(OPTION_IOT_CREDENTIAL_HOST)) == 0)
         {
             if (mallocAndStrcpy_s(&(pKvs->pIotCredentialHost), pValue) != 0)
             {
@@ -829,7 +836,7 @@ int KvsApp_setoption(KvsAppHandle handle, const char *pcOptionName, const char *
                 res = ERRNO_FAIL;
             }
         }
-        else if (strcmp(pcOptionName, OPTION_IOT_ROLE_ALIAS) == 0)
+        else if (strncmp(pcOptionName, (const char *)OPTION_IOT_ROLE_ALIAS, sizeof(OPTION_IOT_ROLE_ALIAS)) == 0)
         {
             if (mallocAndStrcpy_s(&(pKvs->pIotRoleAlias), pValue) != 0)
             {
@@ -837,7 +844,7 @@ int KvsApp_setoption(KvsAppHandle handle, const char *pcOptionName, const char *
                 res = ERRNO_FAIL;
             }
         }
-        else if (strcmp(pcOptionName, OPTION_IOT_THING_NAME) == 0)
+        else if (strncmp(pcOptionName, (const char *)OPTION_IOT_THING_NAME, sizeof(OPTION_IOT_THING_NAME)) == 0)
         {
             if (mallocAndStrcpy_s(&(pKvs->pIotThingName), pValue) != 0)
             {
@@ -845,7 +852,7 @@ int KvsApp_setoption(KvsAppHandle handle, const char *pcOptionName, const char *
                 res = ERRNO_FAIL;
             }
         }
-        else if (strcmp(pcOptionName, OPTION_IOT_X509_ROOTCA) == 0)
+        else if (strncmp(pcOptionName, (const char *)OPTION_IOT_X509_ROOTCA, sizeof(OPTION_IOT_X509_ROOTCA)) == 0)
         {
             if (mallocAndStrcpy_s(&(pKvs->pIotX509RootCa), pValue) != 0)
             {
@@ -853,7 +860,7 @@ int KvsApp_setoption(KvsAppHandle handle, const char *pcOptionName, const char *
                 res = ERRNO_FAIL;
             }
         }
-        else if (strcmp(pcOptionName, OPTION_IOT_X509_CERT) == 0)
+        else if (strncmp(pcOptionName, (const char *)OPTION_IOT_X509_CERT, sizeof(OPTION_IOT_X509_CERT)) == 0)
         {
             if (mallocAndStrcpy_s(&(pKvs->pIotX509Certificate), pValue) != 0)
             {
@@ -861,7 +868,7 @@ int KvsApp_setoption(KvsAppHandle handle, const char *pcOptionName, const char *
                 res = ERRNO_FAIL;
             }
         }
-        else if (strcmp(pcOptionName, OPTION_IOT_X509_KEY) == 0)
+        else if (strncmp(pcOptionName, (const char *)OPTION_IOT_X509_KEY, sizeof(OPTION_IOT_X509_KEY)) == 0)
         {
             if (mallocAndStrcpy_s(&(pKvs->pIotX509PrivateKey), pValue) != 0)
             {
@@ -869,7 +876,7 @@ int KvsApp_setoption(KvsAppHandle handle, const char *pcOptionName, const char *
                 res = ERRNO_FAIL;
             }
         }
-        else if (strcmp(pcOptionName, OPTION_KVS_DATA_RETENTION_IN_HOURS) == 0)
+        else if (strncmp(pcOptionName, (const char *)OPTION_KVS_DATA_RETENTION_IN_HOURS, sizeof(OPTION_KVS_DATA_RETENTION_IN_HOURS)) == 0)
         {
             if (pValue == NULL)
             {
@@ -881,7 +888,7 @@ int KvsApp_setoption(KvsAppHandle handle, const char *pcOptionName, const char *
                 pKvs->uDataRetentionInHours = *((unsigned int *)(pValue));
             }
         }
-        else if (strcmp(pcOptionName, OPTION_KVS_VIDEO_TRACK_INFO) == 0)
+        else if (strncmp(pcOptionName, (const char *)OPTION_KVS_VIDEO_TRACK_INFO, sizeof(OPTION_KVS_VIDEO_TRACK_INFO)) == 0)
         {
             if (pValue == NULL)
             {
@@ -893,7 +900,7 @@ int KvsApp_setoption(KvsAppHandle handle, const char *pcOptionName, const char *
                 LogError("failed to copy video track info");
             }
         }
-        else if (strcmp(pcOptionName, OPTION_KVS_AUDIO_TRACK_INFO) == 0)
+        else if (strncmp(pcOptionName, (const char *)OPTION_KVS_AUDIO_TRACK_INFO, sizeof(OPTION_KVS_AUDIO_TRACK_INFO)) == 0)
         {
             if (pValue == NULL)
             {
@@ -905,7 +912,7 @@ int KvsApp_setoption(KvsAppHandle handle, const char *pcOptionName, const char *
                 LogError("failed to copy audio track info");
             }
         }
-        else if (strcmp(pcOptionName, OPTION_STREAM_POLICY) == 0)
+        else if (strncmp(pcOptionName, (const char *)OPTION_STREAM_POLICY, sizeof(OPTION_STREAM_POLICY)) == 0)
         {
             if (pValue == NULL)
             {
@@ -929,7 +936,7 @@ int KvsApp_setoption(KvsAppHandle handle, const char *pcOptionName, const char *
                 }
             }
         }
-        else if (strcmp(pcOptionName, OPTION_STREAM_POLICY_RING_BUFFER_MEM_LIMIT) == 0)
+        else if (strncmp(pcOptionName, (const char *)OPTION_STREAM_POLICY_RING_BUFFER_MEM_LIMIT, sizeof(OPTION_STREAM_POLICY_RING_BUFFER_MEM_LIMIT)) == 0)
         {
             if (pValue == NULL)
             {
@@ -945,6 +952,52 @@ int KvsApp_setoption(KvsAppHandle handle, const char *pcOptionName, const char *
             {
                 size_t uMemLimit = *((size_t *)pValue);
                 pKvs->xStrategy.xRingBufferPara.uMemLimit = uMemLimit;
+            }
+        }
+        else if (strncmp(pcOptionName, (const char *)OPTION_NETIO_CONNECTION_TIMEOUT, sizeof(OPTION_NETIO_CONNECTION_TIMEOUT)) == 0)
+        {
+            if (pValue == NULL)
+            {
+                LogError("Invalid value set to connection timeout");
+                res = ERRNO_FAIL;
+            }
+            else
+            {
+                unsigned int uConnectionTimeoutMs = *((unsigned int *)pValue);
+                pKvs->xServicePara.uRecvTimeoutMs = uConnectionTimeoutMs;
+                pKvs->xServicePara.uSendTimeoutMs = uConnectionTimeoutMs;
+            }
+        }
+        else if (strncmp(pcOptionName, (const char *)OPTION_NETIO_STREAMING_RECV_TIMEOUT, sizeof(OPTION_NETIO_CONNECTION_TIMEOUT)) == 0)
+        {
+            if (pValue == NULL)
+            {
+                LogError("Invalid value set to streaming recv timeout");
+                res = ERRNO_FAIL;
+            }
+            else
+            {
+                unsigned int uRecvTimeoutMs = *((unsigned int *)pValue);
+                pKvs->xPutMediaPara.uRecvTimeoutMs = uRecvTimeoutMs;
+
+                /* Try to update receive timeout if it's already streaming. */
+                Kvs_putMediaUpdateRecvTimeout(pKvs->xPutMediaHandle, uRecvTimeoutMs);
+            }
+        }
+        else if (strncmp(pcOptionName, (const char *)OPTION_NETIO_STREAMING_SEND_TIMEOUT, sizeof(OPTION_NETIO_STREAMING_SEND_TIMEOUT)) == 0)
+        {
+            if (pValue == NULL)
+            {
+                LogError("Invalid value set to streaming send timeout");
+                res = ERRNO_FAIL;
+            }
+            else
+            {
+                unsigned int uSendTimeoutMs = *((unsigned int *)pValue);
+                pKvs->xPutMediaPara.uRecvTimeoutMs = uSendTimeoutMs;
+
+                /* Try to update send timeout if it's already streaming. */
+                Kvs_putMediaUpdateSendTimeout(pKvs->xPutMediaHandle, uSendTimeoutMs);
             }
         }
         else

--- a/samples/kvsapp-ingenic-t31/source/kvsappcli.c
+++ b/samples/kvsapp-ingenic-t31/source/kvsappcli.c
@@ -142,10 +142,16 @@ int main(int argc, char *argv[])
     {
         while (1)
         {
+            /* FIXME: Check if network is reachable before running KVS. */
+
             if (KvsApp_open(kvsAppHandle) != 0)
             {
                 printf("Failed to open KVS app\r\n");
                 break;
+            }
+            else
+            {
+                printf("KvsApp opened\n");
             }
 
             while (1)
@@ -176,6 +182,10 @@ int main(int argc, char *argv[])
             {
                 printf("Failed to close KVS app\r\n");
                 break;
+            }
+            else
+            {
+                printf("KvsApp closed\n");
             }
         }
     }

--- a/src/include/kvs/restapi.h
+++ b/src/include/kvs/restapi.h
@@ -29,6 +29,9 @@ typedef struct
     char *pcHost;
 
     char *pcPutMediaEndpoint;
+
+    unsigned int uRecvTimeoutMs;
+    unsigned int uSendTimeoutMs;
 } KvsServiceParameter_t;
 
 typedef struct
@@ -58,6 +61,9 @@ typedef struct
     char *pcStreamName;
     FragmentTimecodeType_t xTimecodeType;
     uint64_t uProducerStartTimestampMs;
+
+    unsigned int uRecvTimeoutMs;
+    unsigned int uSendTimeoutMs;
 } KvsPutMediaParameter_t;
 
 typedef struct PutMedia *PutMediaHandle;
@@ -147,5 +153,27 @@ int Kvs_putMediaDoWork(PutMediaHandle xPutMediaHandle);
  * @param[in] xPutMediaHandle The handle of PUT MEDIA
  */
 void Kvs_putMediaFinish(PutMediaHandle xPutMediaHandle);
+
+/**
+ * @brief Update the value of receive timeout.
+ *
+ * Receive timeout has been set in service parameters and is applied during connection setup. It can be altered during streaming.
+ *
+ * @param xPutMediaHandle The handle of PUT MEDIA
+ * @param uRecvTimeoutMs Receiving timeout in milliseconds
+ * @return 0 on success, non-zero value otherwise
+ */
+int Kvs_putMediaUpdateRecvTimeout(PutMediaHandle xPutMediaHandle, unsigned int uRecvTimeoutMs);
+
+/**
+* @brief Update the value of send timeout.
+*
+* Send timeout has been set in service parameters and is applied during connection setup. It can be altered during streaming.
+*
+* @param xPutMediaHandle The handle of PUT MEDIA
+* @param uSendTimeoutMs Receiving timeout in milliseconds
+* @return 0 on success, non-zero value otherwise
+*/
+int Kvs_putMediaUpdateSendTimeout(PutMediaHandle xPutMediaHandle, unsigned int uSendTimeoutMs);
 
 #endif /* KVS_REST_API_H */

--- a/src/source/http_helper.c
+++ b/src/source/http_helper.c
@@ -149,7 +149,7 @@ int Http_executeHttpReq(NetIoHandle xNetIoHandle, const char *pcHttpMethod, cons
     {
         xRes = KVS_ERRNO_FAIL;
     }
-    else if (NetIo_Send(xNetIoHandle, (const unsigned char *)STRING_c_str(xStHttpReq), STRING_length(xStHttpReq)) != KVS_ERRNO_NONE)
+    else if (NetIo_send(xNetIoHandle, (const unsigned char *)STRING_c_str(xStHttpReq), STRING_length(xStHttpReq)) != KVS_ERRNO_NONE)
     {
         xRes = KVS_ERRNO_FAIL;
     }
@@ -198,7 +198,7 @@ int Http_recvHttpRsp(NetIoHandle xNetIoHandle, unsigned int *puHttpStatus, char 
                     break;
                 }
             }
-            if (NetIo_Recv(xNetIoHandle, BUFFER_u_char(xBufRecv) + uBytesTotalReceived, BUFFER_length(xBufRecv) - uBytesTotalReceived, &uBytesReceived) != KVS_ERRNO_NONE ||
+            if (NetIo_recv(xNetIoHandle, BUFFER_u_char(xBufRecv) + uBytesTotalReceived, BUFFER_length(xBufRecv) - uBytesTotalReceived, &uBytesReceived) != KVS_ERRNO_NONE ||
                 uBytesReceived == 0)
             {
                 xRes = KVS_ERRNO_FAIL;

--- a/src/source/iot_credential_provider.c
+++ b/src/source/iot_credential_provider.c
@@ -112,8 +112,8 @@ IotCredentialToken_t *Iot_getCredential(IotCredentialRequest_t *pReq)
         xRes = KVS_ERRNO_FAIL;
     }
     else if (
-        (xNetIoHandle = NetIo_Create()) == NULL ||
-        NetIo_ConnectWithX509(xNetIoHandle, pReq->pCredentialHost, "443", pReq->pRootCA, pReq->pCertificate, pReq->pPrivateKey) != KVS_ERRNO_NONE)
+        (xNetIoHandle = NetIo_create()) == NULL ||
+        NetIo_connectWithX509(xNetIoHandle, pReq->pCredentialHost, "443", pReq->pRootCA, pReq->pCertificate, pReq->pPrivateKey) != KVS_ERRNO_NONE)
     {
         LogError("Failed to connect to %s\r\n", pReq->pCredentialHost);
         xRes = KVS_ERRNO_FAIL;
@@ -165,8 +165,8 @@ IotCredentialToken_t *Iot_getCredential(IotCredentialRequest_t *pReq)
         kvsFree(pRspBody);
     }
 
-    NetIo_Disconnect(xNetIoHandle);
-    NetIo_Terminate(xNetIoHandle);
+    NetIo_disconnect(xNetIoHandle);
+    NetIo_terminate(xNetIoHandle);
     HTTPHeaders_Free(xHttpReqHeaders);
     STRING_delete(xStUri);
 

--- a/src/source/netio.h
+++ b/src/source/netio.h
@@ -25,14 +25,14 @@ typedef struct NetIo *NetIoHandle;
  *
  * @return The network I/O handle
  */
-NetIoHandle NetIo_Create(void);
+NetIoHandle NetIo_create(void);
 
 /**
  * @brief Terminate a network I/O handle
  *
  * @param[in] xNetIoHandle The network I/O handle
  */
-void NetIo_Terminate(NetIoHandle xNetIoHandle);
+void NetIo_terminate(NetIoHandle xNetIoHandle);
 
 /**
  * @brief Connect to a host with port
@@ -42,7 +42,7 @@ void NetIo_Terminate(NetIoHandle xNetIoHandle);
  * @param[in] pcPort The port
  * @return 0 on success, non-zero value otherwise
  */
-int NetIo_Connect(NetIoHandle xNetIoHandle, const char *pcHost, const char *pcPort);
+int NetIo_connect(NetIoHandle xNetIoHandle, const char *pcHost, const char *pcPort);
 
 /**
  * @brief Connect to a host with port and X509 certificates
@@ -55,14 +55,14 @@ int NetIo_Connect(NetIoHandle xNetIoHandle, const char *pcHost, const char *pcPo
  * @param[in] pcPrivKey The x509 client private key
  * @return 0 on success, non-zero value otherwise
  */
-int NetIo_ConnectWithX509(NetIoHandle xNetIoHandle, const char *pcHost, const char *pcPort, const char *pcRootCA, const char *pcCert, const char *pcPrivKey);
+int NetIo_connectWithX509(NetIoHandle xNetIoHandle, const char *pcHost, const char *pcPort, const char *pcRootCA, const char *pcCert, const char *pcPrivKey);
 
 /**
  * @breif Disconnect from a host
  *
  * @param[in] xNetIoHandle The network I/O handle
  */
-void NetIo_Disconnect(NetIoHandle xNetIoHandle);
+void NetIo_disconnect(NetIoHandle xNetIoHandle);
 
 /**
  * @brief Send data
@@ -72,7 +72,7 @@ void NetIo_Disconnect(NetIoHandle xNetIoHandle);
  * @param[in] uBytesToSend The length of data
  * @return 0 on success, non-zero value otherwise
  */
-int NetIo_Send(NetIoHandle xNetIoHandle, const unsigned char *pBuffer, size_t uBytesToSend);
+int NetIo_send(NetIoHandle xNetIoHandle, const unsigned char *pBuffer, size_t uBytesToSend);
 
 /**
  * @brief Receive data
@@ -83,7 +83,7 @@ int NetIo_Send(NetIoHandle xNetIoHandle, const unsigned char *pBuffer, size_t uB
  * @param[out] puBytesReceived The actual bytes received
  * @return 0 on success, non-zero value otherwise
  */
-int NetIo_Recv(NetIoHandle xNetIoHandle, unsigned char *pBuffer, size_t uBufferSize, size_t *puBytesReceived);
+int NetIo_recv(NetIoHandle xNetIoHandle, unsigned char *pBuffer, size_t uBufferSize, size_t *puBytesReceived);
 
 /**
  * @brief Check if any data available
@@ -92,5 +92,23 @@ int NetIo_Recv(NetIoHandle xNetIoHandle, unsigned char *pBuffer, size_t uBufferS
  * @return true if data available, false otherwise
  */
 bool NetIo_isDataAvailable(NetIoHandle xNetIoHandle);
+
+/**
+ * @brief Configure receive timeout.
+ *
+ * @param xNetIoHandle The network I/O handle
+ * @param uRecvTimeoutMs Receive timeout in milliseconds
+ * @return 0 on success, non-zero value otherwise
+ */
+int NetIo_setRecvTimeout(NetIoHandle xNetIoHandle, unsigned int uRecvTimeoutMs);
+
+/**
+ * @brief Configure send timeout.
+ *
+ * @param xNetIoHandle The network I/O handle
+ * @param uSendTimeoutMs Send timeout in milliseconds
+ * @return 0 on success, non-zero value otherwise
+ */
+int NetIo_setSendTimeout(NetIoHandle xNetIoHandle, unsigned int uSendTimeoutMs);
 
 #endif /* NETIO_H */

--- a/src/source/restapi.c
+++ b/src/source/restapi.c
@@ -40,12 +40,12 @@
 #include "netio.h"
 
 #ifndef SAFE_FREE
-#    define SAFE_FREE(a)                                                                                                                                                           \
-        do                                                                                                                                                                         \
-        {                                                                                                                                                                          \
-            kvsFree(a);                                                                                                                                                           \
-            a = NULL;                                                                                                                                                              \
-        } while (0)
+#define SAFE_FREE(a)                                                                                                                                                               \
+    do                                                                                                                                                                             \
+    {                                                                                                                                                                              \
+        kvsFree(a);                                                                                                                                                                \
+        a = NULL;                                                                                                                                                                  \
+    } while (0)
 #endif /* SAFE_FREE */
 
 #define DEFAULT_RECV_BUFSIZE (1024)
@@ -579,7 +579,9 @@ int Kvs_describeStream(KvsServiceParameter_t *pServPara, KvsDescribeStreamParame
         LogError("Failed to sign");
         xRes = KVS_ERRNO_FAIL;
     }
-    else if ((xNetIoHandle = NetIo_Create()) == NULL || NetIo_Connect(xNetIoHandle, pServPara->pcHost, PORT_HTTPS) != KVS_ERRNO_NONE)
+    else if (
+        (xNetIoHandle = NetIo_create()) == NULL || NetIo_setRecvTimeout(xNetIoHandle, pServPara->uRecvTimeoutMs) != KVS_ERRNO_NONE ||
+        NetIo_setSendTimeout(xNetIoHandle, pServPara->uSendTimeoutMs) != KVS_ERRNO_NONE || NetIo_connect(xNetIoHandle, pServPara->pcHost, PORT_HTTPS) != KVS_ERRNO_NONE)
     {
         LogError("Failed to connect to %s\r\n", pServPara->pcHost);
         xRes = KVS_ERRNO_FAIL;
@@ -599,8 +601,8 @@ int Kvs_describeStream(KvsServiceParameter_t *pServPara, KvsDescribeStreamParame
         *puHttpStatusCode = uHttpStatusCode;
     }
 
-    NetIo_Disconnect(xNetIoHandle);
-    NetIo_Terminate(xNetIoHandle);
+    NetIo_disconnect(xNetIoHandle);
+    NetIo_terminate(xNetIoHandle);
     SAFE_FREE(pRspBody);
     HTTPHeaders_Free(xHttpReqHeaders);
     AwsSigV4_Terminate(xAwsSigV4Handle);
@@ -663,7 +665,9 @@ int Kvs_createStream(KvsServiceParameter_t *pServPara, KvsCreateStreamParameter_
         LogError("Failed to sign");
         xRes = KVS_ERRNO_FAIL;
     }
-    else if ((xNetIoHandle = NetIo_Create()) == NULL || NetIo_Connect(xNetIoHandle, pServPara->pcHost, PORT_HTTPS) != KVS_ERRNO_NONE)
+    else if (
+        (xNetIoHandle = NetIo_create()) == NULL || NetIo_setRecvTimeout(xNetIoHandle, pServPara->uRecvTimeoutMs) != KVS_ERRNO_NONE ||
+        NetIo_setSendTimeout(xNetIoHandle, pServPara->uSendTimeoutMs) != KVS_ERRNO_NONE || NetIo_connect(xNetIoHandle, pServPara->pcHost, PORT_HTTPS) != KVS_ERRNO_NONE)
     {
         LogError("Failed to connect to %s\r\n", pServPara->pcHost);
         xRes = KVS_ERRNO_FAIL;
@@ -683,8 +687,8 @@ int Kvs_createStream(KvsServiceParameter_t *pServPara, KvsCreateStreamParameter_
         *puHttpStatusCode = uHttpStatusCode;
     }
 
-    NetIo_Disconnect(xNetIoHandle);
-    NetIo_Terminate(xNetIoHandle);
+    NetIo_disconnect(xNetIoHandle);
+    NetIo_terminate(xNetIoHandle);
     SAFE_FREE(pRspBody);
     HTTPHeaders_Free(xHttpReqHeaders);
     AwsSigV4_Terminate(xAwsSigV4Handle);
@@ -747,7 +751,9 @@ int Kvs_getDataEndpoint(KvsServiceParameter_t *pServPara, KvsGetDataEndpointPara
         LogError("Failed to sign");
         xRes = KVS_ERRNO_FAIL;
     }
-    else if ((xNetIoHandle = NetIo_Create()) == NULL || NetIo_Connect(xNetIoHandle, pServPara->pcHost, PORT_HTTPS) != KVS_ERRNO_NONE)
+    else if (
+        (xNetIoHandle = NetIo_create()) == NULL || NetIo_setRecvTimeout(xNetIoHandle, pServPara->uRecvTimeoutMs) != KVS_ERRNO_NONE ||
+        NetIo_setSendTimeout(xNetIoHandle, pServPara->uSendTimeoutMs) != KVS_ERRNO_NONE || NetIo_connect(xNetIoHandle, pServPara->pcHost, PORT_HTTPS) != KVS_ERRNO_NONE)
     {
         LogError("Failed to connect to %s\r\n", pServPara->pcHost);
         xRes = KVS_ERRNO_FAIL;
@@ -784,8 +790,8 @@ int Kvs_getDataEndpoint(KvsServiceParameter_t *pServPara, KvsGetDataEndpointPara
         }
     }
 
-    NetIo_Disconnect(xNetIoHandle);
-    NetIo_Terminate(xNetIoHandle);
+    NetIo_disconnect(xNetIoHandle);
+    NetIo_terminate(xNetIoHandle);
     SAFE_FREE(pRspBody);
     HTTPHeaders_Free(xHttpReqHeaders);
     AwsSigV4_Terminate(xAwsSigV4Handle);
@@ -856,7 +862,9 @@ int Kvs_putMediaStart(KvsServiceParameter_t *pServPara, KvsPutMediaParameter_t *
         LogError("Failed to sign");
         xRes = KVS_ERRNO_FAIL;
     }
-    else if ((xNetIoHandle = NetIo_Create()) == NULL || NetIo_Connect(xNetIoHandle, pServPara->pcPutMediaEndpoint, PORT_HTTPS) != KVS_ERRNO_NONE)
+    else if (
+        (xNetIoHandle = NetIo_create()) == NULL || NetIo_setRecvTimeout(xNetIoHandle, pServPara->uRecvTimeoutMs) != KVS_ERRNO_NONE ||
+        NetIo_setSendTimeout(xNetIoHandle, pServPara->uSendTimeoutMs) != KVS_ERRNO_NONE || NetIo_connect(xNetIoHandle, pServPara->pcPutMediaEndpoint, PORT_HTTPS) != KVS_ERRNO_NONE)
     {
         LogError("Failed to connect to %s\r\n", pServPara->pcPutMediaEndpoint);
         xRes = KVS_ERRNO_FAIL;
@@ -884,6 +892,10 @@ int Kvs_putMediaStart(KvsServiceParameter_t *pServPara, KvsPutMediaParameter_t *
             }
             else
             {
+                /* Change network I/O receiving timeout for streaming purpose. */
+                NetIo_setRecvTimeout(xNetIoHandle, pPutMediaPara->uRecvTimeoutMs);
+                NetIo_setSendTimeout(xNetIoHandle, pPutMediaPara->uSendTimeoutMs);
+
                 memset(pPutMedia, 0, sizeof(PutMedia_t));
                 pPutMedia->xNetIoHandle = xNetIoHandle;
                 *pPutMediaHandle = pPutMedia;
@@ -894,8 +906,8 @@ int Kvs_putMediaStart(KvsServiceParameter_t *pServPara, KvsPutMediaParameter_t *
 
     if (!bKeepNetIo)
     {
-        NetIo_Disconnect(xNetIoHandle);
-        NetIo_Terminate(xNetIoHandle);
+        NetIo_disconnect(xNetIoHandle);
+        NetIo_terminate(xNetIoHandle);
     }
     SAFE_FREE(pRspBody);
     HTTPHeaders_Free(xHttpReqHeaders);
@@ -933,10 +945,10 @@ int Kvs_putMediaUpdate(PutMediaHandle xPutMediaHandle, uint8_t *pMkvHeader, size
         }
         else
         {
-            if (NetIo_Send(pPutMedia->xNetIoHandle, (const unsigned char *)pcChunkedHeader, (size_t)xChunkedHeaderLen) != 0 ||
-                NetIo_Send(pPutMedia->xNetIoHandle, pMkvHeader, uMkvHeaderLen) != 0 ||
-                (pData != NULL && uDataLen > 0 && NetIo_Send(pPutMedia->xNetIoHandle, pData, uDataLen) != 0) ||
-                NetIo_Send(pPutMedia->xNetIoHandle, (const unsigned char *)pcChunkedEnd, strlen(pcChunkedEnd)) != 0)
+            if (NetIo_send(pPutMedia->xNetIoHandle, (const unsigned char *)pcChunkedHeader, (size_t)xChunkedHeaderLen) != 0 ||
+                NetIo_send(pPutMedia->xNetIoHandle, pMkvHeader, uMkvHeaderLen) != 0 ||
+                (pData != NULL && uDataLen > 0 && NetIo_send(pPutMedia->xNetIoHandle, pData, uDataLen) != 0) ||
+                NetIo_send(pPutMedia->xNetIoHandle, (const unsigned char *)pcChunkedEnd, strlen(pcChunkedEnd)) != 0)
             {
                 LogError("Failed to send data frame");
                 xRes = KVS_ERRNO_FAIL;
@@ -974,8 +986,8 @@ int Kvs_putMediaUpdateRaw(PutMediaHandle xPutMediaHandle, uint8_t *pBuf, size_t 
         }
         else
         {
-            if (NetIo_Send(pPutMedia->xNetIoHandle, (const unsigned char *)pcChunkedHeader, (size_t)xChunkedHeaderLen) != 0 ||
-                NetIo_Send(pPutMedia->xNetIoHandle, pBuf, uLen) != 0 || NetIo_Send(pPutMedia->xNetIoHandle, (const unsigned char *)pcChunkedEnd, strlen(pcChunkedEnd)) != 0)
+            if (NetIo_send(pPutMedia->xNetIoHandle, (const unsigned char *)pcChunkedHeader, (size_t)xChunkedHeaderLen) != 0 ||
+                NetIo_send(pPutMedia->xNetIoHandle, pBuf, uLen) != 0 || NetIo_send(pPutMedia->xNetIoHandle, (const unsigned char *)pcChunkedEnd, strlen(pcChunkedEnd)) != 0)
             {
                 LogError("Failed to send data frame");
                 xRes = KVS_ERRNO_FAIL;
@@ -1021,7 +1033,7 @@ int Kvs_putMediaDoWork(PutMediaHandle xPutMediaHandle)
                 break;
             }
 
-            if (NetIo_Recv(pPutMedia->xNetIoHandle, BUFFER_u_char(xBufRecv) + uBytesTotalReceived, BUFFER_length(xBufRecv) - uBytesTotalReceived, &uBytesReceived) !=
+            if (NetIo_recv(pPutMedia->xNetIoHandle, BUFFER_u_char(xBufRecv) + uBytesTotalReceived, BUFFER_length(xBufRecv) - uBytesTotalReceived, &uBytesReceived) !=
                 KVS_ERRNO_NONE)
             {
                 LogError("Failed to receive");
@@ -1071,9 +1083,51 @@ void Kvs_putMediaFinish(PutMediaHandle xPutMediaHandle)
     {
         if (pPutMedia->xNetIoHandle != NULL)
         {
-            NetIo_Disconnect(pPutMedia->xNetIoHandle);
-            NetIo_Terminate(pPutMedia->xNetIoHandle);
+            NetIo_disconnect(pPutMedia->xNetIoHandle);
+            NetIo_terminate(pPutMedia->xNetIoHandle);
         }
         kvsFree(pPutMedia);
     }
+}
+
+int Kvs_putMediaUpdateRecvTimeout(PutMediaHandle xPutMediaHandle, unsigned int uRecvTimeoutMs)
+{
+    int xRes = KVS_ERRNO_NONE;
+    PutMedia_t *pPutMedia = xPutMediaHandle;
+
+    if (pPutMedia == NULL || pPutMedia->xNetIoHandle == NULL)
+    {
+        xRes = KVS_ERRNO_FAIL;
+    }
+    else if (NetIo_setRecvTimeout(pPutMedia->xNetIoHandle, uRecvTimeoutMs) != KVS_ERRNO_NONE)
+    {
+        xRes = KVS_ERRNO_FAIL;
+    }
+    else
+    {
+        /* nop */
+    }
+
+    return xRes;
+}
+
+int Kvs_putMediaUpdateSendTimeout(PutMediaHandle xPutMediaHandle, unsigned int uSendTimeoutMs)
+{
+    int xRes = KVS_ERRNO_NONE;
+    PutMedia_t *pPutMedia = xPutMediaHandle;
+
+    if (pPutMedia == NULL || pPutMedia->xNetIoHandle == NULL)
+    {
+        xRes = KVS_ERRNO_FAIL;
+    }
+    else if (NetIo_setSendTimeout(pPutMedia->xNetIoHandle, uSendTimeoutMs) != KVS_ERRNO_NONE)
+    {
+        xRes = KVS_ERRNO_FAIL;
+    }
+    else
+    {
+        /* nop */
+    }
+
+    return xRes;
 }


### PR DESCRIPTION
*   Add send and receive timeout in NetIo
*   Add send and receive timeout in service parameter and put media parameter. The send/recv timeout in service parameter are for connection timeout. The send/recv timeout in put media is for streaming purpose. Connection timeout is usually larger than streaming timeout because it may take much time in SSL handshake.
*   Add options of connection timeout, streaming send/recv timeout in kvsapp.
*   Correct naming style in NetIo
*   With non-block API, it resolve the issue of hangs in KvsApp_doWork when network is down.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
