### PR TITLE
Add safe check when getting ISO 8601 time

### DIFF
--- a/src/port/port_linux.c
+++ b/src/port/port_linux.c
@@ -22,6 +22,8 @@
 #include "kvs/errors.h"
 #include "kvs/port.h"
 
+#define PAST_OLD_TIME_IN_EPOCH 1600000000
+
 int platformInit(void)
 {
     int xRes = KVS_ERRNO_NONE;
@@ -43,7 +45,15 @@ int getTimeInIso8601(char *pBuf, size_t uBufSize)
     else
     {
         xTimeUtcNow = time(NULL);
-        strftime(pBuf, DATE_TIME_ISO_8601_FORMAT_STRING_SIZE, "%Y%m%dT%H%M%SZ", gmtime(&xTimeUtcNow));
+        /* Current time should not less than a specific old time. If it does, then it means system time is incorrect. */
+        if ((long)xTimeUtcNow < (long)PAST_OLD_TIME_IN_EPOCH)
+        {
+            xRes = KVS_ERRNO_FAIL;
+        }
+        else
+        {
+            strftime(pBuf, DATE_TIME_ISO_8601_FORMAT_STRING_SIZE, "%Y%m%dT%H%M%SZ", gmtime(&xTimeUtcNow));
+        }
     }
 
     return xRes;


### PR DESCRIPTION
AWS RESTful API would check if ISO 8601 time is today.  If system time isn't set correctly, then the request would fail and get a HTTP 403 error.  This solution add an old time and compare system time to it to see if system time has been set correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
