### PR TITLE
remove T31 patch directory before create it

### DIFF
--- a/samples/kvsapp-ingenic-t31/CMakeLists.txt
+++ b/samples/kvsapp-ingenic-t31/CMakeLists.txt
@@ -84,7 +84,8 @@ target_link_libraries(${APP_NAME}-static
 # create sample patch
 set(INGENIC_T31_KVS_SAMPLE_DIR ${PROJECT_BINARY_DIR}/ingenic_t31_kvs_sample)
 
-add_custom_command(TARGET ${APP_NAME} POST_BUILD 
+add_custom_command(TARGET ${APP_NAME} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E rm -rf         ${INGENIC_T31_KVS_SAMPLE_DIR}
     COMMAND ${CMAKE_COMMAND} -E make_directory ${INGENIC_T31_KVS_SAMPLE_DIR}
     COMMAND ${CMAKE_COMMAND} -E copy           ${CMAKE_CURRENT_SOURCE_DIR}/res/CMakeLists.txt ${INGENIC_T31_KVS_SAMPLE_DIR}/CMakeLists.txt
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${LIBRARY_OUTPUT_PATH} ${INGENIC_T31_KVS_SAMPLE_DIR}/lib


### PR DESCRIPTION
Remove T31 patch directory before create it, otherwise it may failed to copy new files or new directories.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
