### PR TITLE
Fix busy looping when no frame available as connection established.

### DIFF
--- a/app/kvsapp/source/kvsapp.c
+++ b/app/kvsapp/source/kvsapp.c
@@ -1266,12 +1266,12 @@ int KvsApp_doWork(KvsAppHandle handle)
                 res = ERRNO_FAIL;
                 break;
             }
-
-            if (xSendCnt == 0)
-            {
-                prvSleepInMs(50);
-            }
         } while (false);
+
+        if (xSendCnt == 0)
+        {
+            prvSleepInMs(50);
+        }
     }
 
     return res;


### PR DESCRIPTION
As connection established, it'll flush frames until there is a key frame. If there is no frames available, it'll make the doWork as a busy loop.

This solution checks if there is nothing to do, then delay a little.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
