### PR TITLE
Register interrupt signal handler so user can exit sample by using Ctrl+c

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,10 @@ if (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
 endif()
 
+# Checking platform properties
+include(CheckIncludeFiles)
+check_include_files(signal.h HAVE_SIGNAL_H)
+
 # Print option values
 message(STATUS "BUILD_SHARED_SAMPLES            = ${BUILD_SHARED_SAMPLES}")
 message(STATUS "BUILD_STATIC_SAMPLES            = ${BUILD_STATIC_SAMPLES}")

--- a/samples/kvsapp/CMakeLists.txt
+++ b/samples/kvsapp/CMakeLists.txt
@@ -17,6 +17,11 @@ if(${USE_POOL_ALLOCATOR_ALL})
     set(LINKER_FLAGS_FOR_MEM_WRAPPER -Wl,--wrap,malloc -Wl,--wrap,realloc -Wl,--wrap,calloc -Wl,--wrap,free)
 endif()
 
+unset(COMPILE_FLAGS_FOR_SIGNAL_H)
+if(${HAVE_SIGNAL_H})
+    set(COMPILE_FLAGS_FOR_SIGNAL_H -DHAVE_SIGNAL_H=1)
+endif()
+
 if(${BUILD_SHARED_SAMPLES})
     add_executable(${APP_NAME} ${${APP_NAME}_SRC})
     set_target_properties(${APP_NAME} PROPERTIES OUTPUT_NAME ${APP_NAME})
@@ -24,6 +29,7 @@ if(${BUILD_SHARED_SAMPLES})
     target_compile_definitions(${APP_NAME} PUBLIC -D_XOPEN_SOURCE=600 -D_POSIX_C_SOURCE=200112L)
     target_compile_definitions(${APP_NAME} PUBLIC -DBUILD_EXECUTABLE_WITH_SHARED_LIBRARY)
     target_compile_definitions(${APP_NAME} PUBLIC ${COMPILE_FLAGS_FOR_POOL_ALLOCATOR})
+    target_compile_definitions(${APP_NAME} PUBLIC ${COMPILE_FLAGS_FOR_SIGNAL_H})
     target_link_libraries(${APP_NAME}
         kvsapp-shared
         samplescommon-shared
@@ -38,6 +44,7 @@ if(${BUILD_STATIC_SAMPLES})
     target_compile_definitions(${APP_NAME}-static PUBLIC -D_XOPEN_SOURCE=600 -D_POSIX_C_SOURCE=200112L)
     target_compile_definitions(${APP_NAME}-static PUBLIC -DBUILD_EXECUTABLE_WITH_STATIC_LIBRARY)
     target_compile_definitions(${APP_NAME}-static PUBLIC ${COMPILE_FLAGS_FOR_POOL_ALLOCATOR})
+    target_compile_definitions(${APP_NAME}-static PUBLIC ${COMPILE_FLAGS_FOR_SIGNAL_H})
     target_link_libraries(${APP_NAME}-static
         kvsapp-static
         samplescommon-static


### PR DESCRIPTION
When user press Ctrl+c, it'll send an interrupt signal to program and the default behavior is exiting the program. This commit adds an interrupt signal handler. When user press Ctrl+c, the handler sets a global variable to let each thread know it's about exiting. If something stuck there, user can press Ctrl+c again and it'll exit program immediately.

Once we can exit program gracefully, we can use valgrid to do some tests like memory leak.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
