### PR TITLE
Add API to get fragment ACK of put media

### DIFF
--- a/app/kvsapp/include/kvs/kvsapp.h
+++ b/app/kvsapp/include/kvs/kvsapp.h
@@ -18,6 +18,7 @@
 
 #include "kvs/kvsapp_options.h"
 #include "kvs/mkv_generator.h"
+#include "kvs/restapi.h"
 #include <inttypes.h>
 
 typedef struct KvsApp *KvsAppHandle;
@@ -122,6 +123,20 @@ int KvsApp_addFrameWithCallbacks(KvsAppHandle handle, uint8_t *pData, size_t uDa
  * @return 0 on success, non-zero value otherwise
  */
 int KvsApp_doWork(KvsAppHandle handle);
+
+/**
+ * @brief Non-blocking read a fragment ACK if any.
+ *
+ * When KvsApp_doWork() is called, it will check if any incoming fragment ACKs, and clear fragment ACKs that buffered in the previous Kvs_putMediaDoWork() call.
+ * Use KvsApp_readFragmentAck() to read one fragment ACK and the return value would be 0. If there is no fragment ACK available, then the return value would be non-zero value.
+ *
+ * @param[in] handle The handle of PUT MEDIA
+ * @param[out] peAckEventType Pointer to the fragment ACK event type
+ * @param[out] puFragmentTimecode Pointer to the fragment timecode
+ * @param[out] puErrorId Pointer to the error ID
+ * @return 0 on success, non-zero value otherwise
+ */
+int KvsApp_readFragmentAck(KvsAppHandle handle, ePutMediaFragmentAckEventType *peAckEventType, uint64_t *puFragmentTimecode, unsigned int *puErrorId);
 
 /**
  * Get the memory used in the stream buffer.

--- a/app/kvsapp/source/kvsapp.c
+++ b/app/kvsapp/source/kvsapp.c
@@ -1277,6 +1277,23 @@ int KvsApp_doWork(KvsAppHandle handle)
     return res;
 }
 
+int KvsApp_readFragmentAck(KvsAppHandle handle, ePutMediaFragmentAckEventType *peAckEventType, uint64_t *puFragmentTimecode, unsigned int *puErrorId)
+{
+    int res = ERRNO_NONE;
+    KvsApp_t *pKvs = (KvsApp_t *)handle;
+
+    if (pKvs == NULL)
+    {
+        res = ERRNO_FAIL;
+    }
+    else
+    {
+        res = Kvs_putMediaReadFragmentAck(pKvs->xPutMediaHandle, peAckEventType, puFragmentTimecode, puErrorId);
+    }
+
+    return res;
+}
+
 size_t KvsApp_getStreamMemStatTotal(KvsAppHandle handle)
 {
     size_t uMemTotal = 0;

--- a/src/include/kvs/restapi.h
+++ b/src/include/kvs/restapi.h
@@ -68,6 +68,17 @@ typedef struct
 
 typedef struct PutMedia *PutMediaHandle;
 
+/* PUT MEDIA Fragment ACK event type */
+typedef enum
+{
+    eUnknown = 0,
+    eBuffering,
+    eReceived,
+    ePersisted,
+    eError,
+    eIdle
+} ePutMediaFragmentAckEventType;
+
 /**
  * @brief Describe stream
  *
@@ -159,8 +170,8 @@ void Kvs_putMediaFinish(PutMediaHandle xPutMediaHandle);
  *
  * Receive timeout has been set in service parameters and is applied during connection setup. It can be altered during streaming.
  *
- * @param xPutMediaHandle The handle of PUT MEDIA
- * @param uRecvTimeoutMs Receiving timeout in milliseconds
+ * @param[in] xPutMediaHandle The handle of PUT MEDIA
+ * @param[in] uRecvTimeoutMs Receiving timeout in milliseconds
  * @return 0 on success, non-zero value otherwise
  */
 int Kvs_putMediaUpdateRecvTimeout(PutMediaHandle xPutMediaHandle, unsigned int uRecvTimeoutMs);
@@ -170,10 +181,24 @@ int Kvs_putMediaUpdateRecvTimeout(PutMediaHandle xPutMediaHandle, unsigned int u
 *
 * Send timeout has been set in service parameters and is applied during connection setup. It can be altered during streaming.
 *
-* @param xPutMediaHandle The handle of PUT MEDIA
-* @param uSendTimeoutMs Receiving timeout in milliseconds
+* @param[in] xPutMediaHandle The handle of PUT MEDIA
+* @param[in] uSendTimeoutMs Receiving timeout in milliseconds
 * @return 0 on success, non-zero value otherwise
 */
 int Kvs_putMediaUpdateSendTimeout(PutMediaHandle xPutMediaHandle, unsigned int uSendTimeoutMs);
+
+/**
+ * @brief Non-blocking read a fragment ACK if any.
+ *
+ * When Kvs_putMediaDoWork() is called, it will check if any incoming fragment ACKs, and clear fragment ACKs that buffered in the previous Kvs_putMediaDoWork() call.
+ * Use Kvs_putMediaReadFragmentAck() to read one fragment ACK and the return value would be 0. If there is no fragment ACK available, then the return value would be non-zero value.
+ *
+ * @param[in] xPutMediaHandle The handle of PUT MEDIA
+ * @param[out] peAckEventType Pointer to the fragment ACK event type
+ * @param[out] puFragmentTimecode Pointer to the fragment timecode
+ * @param[out] puErrorId Pointer to the error ID
+ * @return 0 on success, non-zero value otherwise
+ */
+int Kvs_putMediaReadFragmentAck(PutMediaHandle xPutMediaHandle, ePutMediaFragmentAckEventType *peAckEventType, uint64_t *puFragmentTimecode, unsigned int *puErrorId);
 
 #endif /* KVS_REST_API_H */


### PR DESCRIPTION
1. Buffer fragment ACKs in each do work and flush previous ACKs.
2. Add API in kvs lib to read buffered ACKs
3. Add API in kvsapp to read buffered ACKs
4. Add related sample code get get fragment ACKs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
