### PR TITLE
Move sleep from sample code to port.

### DIFF
--- a/app/kvsapp/CMakeLists.txt
+++ b/app/kvsapp/CMakeLists.txt
@@ -10,7 +10,6 @@ set(KVSAPP_INC
 add_library(kvsapp STATIC ${KVSAPP_SRC})
 target_include_directories(kvsapp PUBLIC ${KVSAPP_INC})
 target_compile_options(kvsapp PUBLIC --std=c99)
-target_compile_definitions(kvsapp PUBLIC -D_XOPEN_SOURCE=600 -D_POSIX_C_SOURCE=200112L)
 target_link_libraries(kvsapp PUBLIC
     kvs-embedded-c
     aziotsharedutil

--- a/app/kvsapp/source/kvsapp.c
+++ b/app/kvsapp/source/kvsapp.c
@@ -15,7 +15,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
 
 /* Third-party headers */
 #include "azure_c_shared_utility/crt_abstractions.h"
@@ -113,11 +112,6 @@ typedef struct DataFrameUserData
     DataFrameCallbacks_t xCallbacks;
     void *pAppData;
 } DataFrameUserData_t;
-
-static void prvSleepInMs(uint32_t ms)
-{
-    usleep(ms * 1000);
-}
 
 /**
  * Default implementation of OnDataFrameTerminateCallback_t. It calls free() to pData to release resource.
@@ -1277,7 +1271,7 @@ int KvsApp_doWork(KvsAppHandle handle)
 
         if (xSendCnt == 0)
         {
-            prvSleepInMs(50);
+            sleepInMs(50);
         }
     }
 

--- a/samples/kvs-linux/kvs_linux.c
+++ b/samples/kvs-linux/kvs_linux.c
@@ -74,11 +74,6 @@ typedef struct Kvs
 #endif
 } Kvs_t;
 
-static void sleepInMs(uint32_t ms)
-{
-    usleep(ms * 1000);
-}
-
 static int kvsInitialize(Kvs_t *pKvs)
 {
     int res = ERRNO_NONE;

--- a/samples/kvsapp-ingenic-t31/source/kvsappcli.c
+++ b/samples/kvsapp-ingenic-t31/source/kvsappcli.c
@@ -42,11 +42,6 @@ static T31VideoHandle videoHandle = NULL;
 static T31AudioHandle audioHandle = NULL;
 #endif /* ENABLE_AUDIO_TRACK */
 
-static void sleepInMs(uint32_t ms)
-{
-    usleep(ms * 1000);
-}
-
 static int setKvsAppOptions(KvsAppHandle kvsAppHandle)
 {
     int res = ERRNO_NONE;

--- a/samples/kvsapp-ingenic-t31/source/t31_audio.c
+++ b/samples/kvsapp-ingenic-t31/source/t31_audio.c
@@ -83,7 +83,7 @@ typedef struct T31Audio
 #endif /* USE_AUDIO_AAC */
 } T31Audio_t;
 
-static void sleepInMs(uint32_t ms)
+static void prvSleepInMs(uint32_t ms)
 {
     usleep(ms * 1000);
 }
@@ -504,7 +504,7 @@ void T31Audio_terminate(T31AudioHandle handle)
         pAudio->isTerminating = true;
         while (!pAudio->isTerminated)
         {
-            sleepInMs(10);
+            prvSleepInMs(10);
         }
 
         pthread_join(pAudio->tid, NULL);

--- a/samples/kvsapp-ingenic-t31/source/t31_video.c
+++ b/samples/kvsapp-ingenic-t31/source/t31_video.c
@@ -50,7 +50,7 @@ typedef struct T31Video
 
 extern struct chn_conf chn[];
 
-static void sleepInMs(uint32_t ms)
+static void prvSleepInMs(uint32_t ms)
 {
     usleep(ms * 1000);
 }
@@ -299,7 +299,7 @@ void T31Video_terminate(T31VideoHandle handle)
         pVideo->isTerminating = true;
         while (!pVideo->isTerminated)
         {
-            sleepInMs(10);
+            prvSleepInMs(10);
         }
 
         pthread_join(pVideo->tid, NULL);

--- a/samples/kvsapp/kvsappcli.c
+++ b/samples/kvsapp/kvsappcli.c
@@ -80,11 +80,6 @@ static void signalHandler(int signum)
 }
 #endif /* HAVE_SIGNAL_H */
 
-static void sleepInMs(uint32_t ms)
-{
-    usleep(ms * 1000);
-}
-
 static void *videoThread(void *arg)
 {
     int res = 0;

--- a/samples/mkv_uploader/mkv_uploader.c
+++ b/samples/mkv_uploader/mkv_uploader.c
@@ -61,11 +61,6 @@ typedef struct Kvs
     bool bIsFileUploaded;
 } Kvs_t;
 
-static void sleepInMs(uint32_t ms)
-{
-    usleep(ms * 1000);
-}
-
 static int kvsInitialize(Kvs_t *pKvs, char *pcMkvFileName)
 {
     int res = ERRNO_NONE;

--- a/src/include/kvs/port.h
+++ b/src/include/kvs/port.h
@@ -54,4 +54,11 @@ uint64_t getEpochTimestampInMs(void);
  */
 uint8_t getRandomNumber(void);
 
+/**
+ * @brief sleep in milliseconds.
+ *
+ * @param[in] ms milliseconds to sleep
+ */
+void sleepInMs(uint32_t ms);
+
 #endif /* KVS_PORT_H */

--- a/src/port/port_amebapro.c
+++ b/src/port/port_amebapro.c
@@ -18,6 +18,10 @@
 #include <sys/time.h>
 #include <time.h>
 
+/* Headers for FreeRTOS */
+#include "FreeRTOS.h"
+#include "task.h"
+
 #include "kvs/errors.h"
 #include "kvs/port.h"
 
@@ -62,4 +66,9 @@ uint64_t getEpochTimestampInMs(void)
 uint8_t getRandomNumber(void)
 {
     return (uint8_t)rand();
+}
+
+void sleepInMs(uint32_t ms)
+{
+    vTaskDelay( ms / portTICK_PERIOD_MS );
 }

--- a/src/port/port_esp32.c
+++ b/src/port/port_esp32.c
@@ -63,3 +63,8 @@ uint8_t getRandomNumber(void)
 {
     return (uint8_t)rand();
 }
+
+void sleepInMs(uint32_t ms)
+{
+    vTaskDelay( ms / portTICK_PERIOD_MS );
+}

--- a/src/port/port_linux.c
+++ b/src/port/port_linux.c
@@ -18,6 +18,7 @@
 #include <stdlib.h>
 #include <sys/time.h>
 #include <time.h>
+#include <unistd.h>
 
 #include "kvs/errors.h"
 #include "kvs/port.h"
@@ -73,4 +74,9 @@ uint64_t getEpochTimestampInMs(void)
 uint8_t getRandomNumber(void)
 {
     return (uint8_t)rand();
+}
+
+void sleepInMs(uint32_t ms)
+{
+    usleep(ms * 1000);
 }


### PR DESCRIPTION
KvsApp needs sleep in milliseconds and current design would make KvsApp dependend on Linux platform. Move the sleepInMs to port_linux.c to remove platform dependency.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
