### PR TITLE
Add option configuration in sample kvsapp and kvsapp-ingenic-t31

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ option(BOARD_INGENIC_T31                "Build board Ingenic T31"               
 option(BOARD_RPI                        "Build board Raspberry Pi"                          OFF)
 option(USE_POOL_ALLOCATOR_LIB           "Use pool allocator on KVS lib only"                OFF)
 option(USE_POOL_ALLOCATOR_ALL           "Apply pool allocator on KVS lib and executable"    OFF)
+option(SAMPLE_OPTIONS_FROM_ENV_VAR      "Sample reads options from environment variable"    ON)
 
 # Verify and resolve options
 if(${BOARD_INGENIC_T31})
@@ -37,6 +38,7 @@ message(STATUS "BUILD_AAC_ENCODER               = ${BUILD_AAC_ENCODER}")
 message(STATUS "BOARD_INGENIC_T31               = ${BOARD_INGENIC_T31}")
 message(STATUS "USE_POOL_ALLOCATOR_LIB          = ${USE_POOL_ALLOCATOR_LIB}")
 message(STATUS "USE_POOL_ALLOCATOR_ALL          = ${USE_POOL_ALLOCATOR_ALL}")
+message(STATUS "SAMPLE_OPTIONS_FROM_ENV_VAR     = ${SAMPLE_OPTIONS_FROM_ENV_VAR}")
 message(STATUS "CMAKE_BUILD_TYPE                = ${CMAKE_BUILD_TYPE}")
 
 # Make warning as error

--- a/app/kvsapp/include/kvs/kvsapp.h
+++ b/app/kvsapp/include/kvs/kvsapp.h
@@ -50,7 +50,7 @@ typedef struct DataFrameCallbacks
  * @param[in] pcStreamName KVS stream name
  * @return KVS application handle
  */
-KvsAppHandle KvsApp_create(char *pcHost, char *pcRegion, char *pcService, char *pcStreamName);
+KvsAppHandle KvsApp_create(const char *pcHost, const char *pcRegion, const char *pcService, const char *pcStreamName);
 
 /**
  * Terminate a KVS application.

--- a/app/kvsapp/source/kvsapp.c
+++ b/app/kvsapp/source/kvsapp.c
@@ -702,7 +702,7 @@ static int prvPutMediaSendData(KvsApp_t *pKvs, int *pxSendCnt)
     return res;
 }
 
-KvsAppHandle KvsApp_create(char *pcHost, char *pcRegion, char *pcService, char *pcStreamName)
+KvsAppHandle KvsApp_create(const char *pcHost, const char *pcRegion, const char *pcService, const char *pcStreamName)
 {
     int res = ERRNO_NONE;
     KvsApp_t *pKvs = NULL;

--- a/samples/kvsapp-ingenic-t31/CMakeLists.txt
+++ b/samples/kvsapp-ingenic-t31/CMakeLists.txt
@@ -21,11 +21,17 @@ set(${APP_NAME}_SRC
     source/kvsappcli.c
     source/t31_video.c
     source/t31_audio.c
+    source/option_configuration.c
 )
 
 set(${APP_NAME}_INC
     include
 )
+
+unset(COMPILE_FLAGS_FOR_SAMPLE_OPTIONS_FROM_ENV_VAR)
+if(${SAMPLE_OPTIONS_FROM_ENV_VAR})
+    set(COMPILE_FLAGS_FOR_SAMPLE_OPTIONS_FROM_ENV_VAR -DSAMPLE_OPTIONS_FROM_ENV_VAR)
+endif()
 
 unset(COMPILE_FLAGS_FOR_POOL_ALLOCATOR)
 if(${USE_POOL_ALLOCATOR_LIB})
@@ -47,6 +53,7 @@ set_target_properties(${APP_NAME} PROPERTIES OUTPUT_NAME ${APP_NAME})
 target_compile_definitions(${APP_NAME} PUBLIC -D_XOPEN_SOURCE=600 -D_POSIX_C_SOURCE=200112L)
 target_compile_definitions(${APP_NAME} PUBLIC -DBUILD_EXECUTABLE_WITH_SHARED_LIBRARY)
 target_compile_definitions(${APP_NAME} PUBLIC ${COMPILE_FLAGS_FOR_POOL_ALLOCATOR})
+target_compile_definitions(${APP_NAME} PUBLIC ${COMPILE_FLAGS_FOR_SAMPLE_OPTIONS_FROM_ENV_VAR})
 target_include_directories(${APP_NAME} PUBLIC ${${APP_NAME}_INC})
 target_link_directories(${APP_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/sdk/lib/uclibc)
 target_link_libraries(${APP_NAME}
@@ -67,6 +74,7 @@ set_target_properties(${APP_NAME}-static PROPERTIES OUTPUT_NAME ${APP_NAME}-stat
 target_compile_definitions(${APP_NAME}-static PUBLIC -D_XOPEN_SOURCE=600 -D_POSIX_C_SOURCE=200112L)
 target_compile_definitions(${APP_NAME}-static PUBLIC -DBUILD_EXECUTABLE_WITH_STATIC_LIBRARY)
 target_compile_definitions(${APP_NAME}-static PUBLIC ${COMPILE_FLAGS_FOR_POOL_ALLOCATOR})
+target_compile_definitions(${APP_NAME}-static PUBLIC ${COMPILE_FLAGS_FOR_SAMPLE_OPTIONS_FROM_ENV_VAR})
 target_include_directories(${APP_NAME}-static PUBLIC ${${APP_NAME}_INC})
 target_link_directories(${APP_NAME}-static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/sdk/lib/uclibc)
 target_link_libraries(${APP_NAME}-static
@@ -85,16 +93,16 @@ target_link_libraries(${APP_NAME}-static
 set(INGENIC_T31_KVS_SAMPLE_DIR ${PROJECT_BINARY_DIR}/ingenic_t31_kvs_sample)
 
 add_custom_command(TARGET ${APP_NAME} POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E rm -rf         ${INGENIC_T31_KVS_SAMPLE_DIR}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${INGENIC_T31_KVS_SAMPLE_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy           ${CMAKE_CURRENT_SOURCE_DIR}/res/CMakeLists.txt ${INGENIC_T31_KVS_SAMPLE_DIR}/CMakeLists.txt
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${LIBRARY_OUTPUT_PATH} ${INGENIC_T31_KVS_SAMPLE_DIR}/lib
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/sdk/lib/uclibc ${INGENIC_T31_KVS_SAMPLE_DIR}/uclibc
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/sdk/include/imp ${INGENIC_T31_KVS_SAMPLE_DIR}/include/imp
-    COMMAND ${CMAKE_COMMAND} -E copy           ${CMAKE_CURRENT_SOURCE_DIR}/sdk/samples/libimp-samples/sample-common.h ${INGENIC_T31_KVS_SAMPLE_DIR}/include/sample-common.h
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/source ${INGENIC_T31_KVS_SAMPLE_DIR}/source
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/include ${INGENIC_T31_KVS_SAMPLE_DIR}/include
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/app/aac-encoder/include ${INGENIC_T31_KVS_SAMPLE_DIR}/include
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/app/kvsapp/include ${INGENIC_T31_KVS_SAMPLE_DIR}/include
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/src/include ${INGENIC_T31_KVS_SAMPLE_DIR}/include
+    COMMAND ${CMAKE_COMMAND} -E remove_directory    ${INGENIC_T31_KVS_SAMPLE_DIR}
+    COMMAND ${CMAKE_COMMAND} -E make_directory      ${INGENIC_T31_KVS_SAMPLE_DIR}
+    COMMAND ${CMAKE_COMMAND} -E copy                ${CMAKE_CURRENT_SOURCE_DIR}/res/CMakeLists.txt ${INGENIC_T31_KVS_SAMPLE_DIR}/CMakeLists.txt
+    COMMAND ${CMAKE_COMMAND} -E copy_directory      ${LIBRARY_OUTPUT_PATH} ${INGENIC_T31_KVS_SAMPLE_DIR}/lib
+    COMMAND ${CMAKE_COMMAND} -E copy_directory      ${CMAKE_CURRENT_SOURCE_DIR}/sdk/lib/uclibc ${INGENIC_T31_KVS_SAMPLE_DIR}/uclibc
+    COMMAND ${CMAKE_COMMAND} -E copy_directory      ${CMAKE_CURRENT_SOURCE_DIR}/sdk/include/imp ${INGENIC_T31_KVS_SAMPLE_DIR}/include/imp
+    COMMAND ${CMAKE_COMMAND} -E copy                ${CMAKE_CURRENT_SOURCE_DIR}/sdk/samples/libimp-samples/sample-common.h ${INGENIC_T31_KVS_SAMPLE_DIR}/include/sample-common.h
+    COMMAND ${CMAKE_COMMAND} -E copy_directory      ${CMAKE_CURRENT_SOURCE_DIR}/source ${INGENIC_T31_KVS_SAMPLE_DIR}/source
+    COMMAND ${CMAKE_COMMAND} -E copy_directory      ${CMAKE_CURRENT_SOURCE_DIR}/include ${INGENIC_T31_KVS_SAMPLE_DIR}/include
+    COMMAND ${CMAKE_COMMAND} -E copy_directory      ${PROJECT_SOURCE_DIR}/app/aac-encoder/include ${INGENIC_T31_KVS_SAMPLE_DIR}/include
+    COMMAND ${CMAKE_COMMAND} -E copy_directory      ${PROJECT_SOURCE_DIR}/app/kvsapp/include ${INGENIC_T31_KVS_SAMPLE_DIR}/include
+    COMMAND ${CMAKE_COMMAND} -E copy_directory      ${PROJECT_SOURCE_DIR}/src/include ${INGENIC_T31_KVS_SAMPLE_DIR}/include
 )

--- a/samples/kvsapp-ingenic-t31/README.md
+++ b/samples/kvsapp-ingenic-t31/README.md
@@ -10,7 +10,7 @@ These are prerequisites:
 
 ## Device setup
 
-Please follow "T31 SNIPE_user_guide.pdf" in the SDK to setup device and network.
+Please follow "T31 SNIPE_user_guide.pdf" in the SDK to setup device and network. You can put following settings in `/system/init/app_init.sh` if you want.
 
 ### Setup DNS server
 
@@ -101,7 +101,9 @@ Please add toolchain "mips-gcc472-glibc216-64bit" into you path.  Ex.
 
 ## Configure sample settings
 
-You need to configure sample settings in file "*samples/kvsapp-ingenic-t31/include/sample_config.h*".
+You can skip this section if you want to use environment variables as sample configureation.
+
+You can put sample default configurations in file "*samples/kvsapp-ingenic-t31/include/sample_config.h*".
 
 ## Build
 
@@ -124,10 +126,17 @@ After build completed, there will be exectuable files named "kvsappcli-ingenic-t
 
 # Run sample
 
-Now the executable is on the device, use the following command to run this sample.
+If you didn't configure sample configurations in file "*samples/kvsapp-ingenic-t31/include/sample_config.h*", then you need to configure the following environment variables.
+
+    export AWS_ACCESS_KEY_ID=xxxxxxxxxxxxxxxxxxxx
+    export AWS_SECRET_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    export AWS_DEFAULT_REGION=us-east-1
+    export AWS_KVS_HOST=kinesisvideo.us-east-1.amazonaws.com
+
+Now the executable is on the device, use the following command to run this sample. Argument `kvs-stream-name` is KVS stream name to be uploaded and it's optional. It'll use stream name in `sample_config.h` if this argument is not present.
 
     cd /mnt
-    ./kvsappcli-ingenic-t31-static
+    ./kvsappcli-ingenic-t31-static [kvs-stream-name]
 
 You wold see following log if everythins works fine.
 

--- a/samples/kvsapp-ingenic-t31/include/option_configuration.h
+++ b/samples/kvsapp-ingenic-t31/include/option_configuration.h
@@ -1,0 +1,55 @@
+#ifndef SAMPLE_OPTIONS_H
+#define SAMPLE_OPTIONS_H
+
+/**
+ * @brief Get AWS access key
+ *
+ * It searches AWS access key with following order:
+ *      1. environment variable
+ *      2. sample_config.h
+ *
+ * @return AWS access key
+ */
+const char *OptCfg_getAwsAccessKey();
+
+/**
+ * @brief Get AWS secret access key
+ *
+ * It searches AWS secret access key with following order:
+ *      1. environment variable
+ *      2. sample_config.h
+ *
+ * @return AWS secret access key
+ */
+const char *OptCfg_getAwsSecretAccessKey();
+
+/**
+ * @brief Get AWS region
+ *
+ * It searches AWS region with following order:
+ *      1. environment variable
+ *      2. sample_config.h
+ *
+ * @return AWS region
+ */
+const char *OptCfg_getRegion();
+
+/**
+ * @brief Get AWS KVS service name
+ *
+ * @return KVS service name
+ */
+const char *OptCfg_getServiceKinesisVideo();
+
+/**
+ * @brief Get KVS host name
+ *
+ * It searches KVS host name with following order:
+ *      1. environment variable
+ *      2. sample_config.h
+ *
+ * @return KVS host name
+ */
+const char *OptCfg_getHostKinesisVideo();
+
+#endif /* SAMPLE_OPTIONS_H */

--- a/samples/kvsapp-ingenic-t31/res/CMakeLists.txt
+++ b/samples/kvsapp-ingenic-t31/res/CMakeLists.txt
@@ -6,6 +6,7 @@ set(APP_NAME "kvsappcli-ingenic-t31")
 # Options
 option(USE_POOL_ALLOCATOR_LIB           "Use pool allocator on KVS lib only"                OFF)
 option(USE_POOL_ALLOCATOR_ALL           "Apply pool allocator on KVS lib and executable"    OFF)
+option(SAMPLE_OPTIONS_FROM_ENV_VAR      "Sample reads options from environment variable"    ON)
 
 # Verify and resolve options
 if(${USE_POOL_ALLOCATOR_ALL})
@@ -34,6 +35,11 @@ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -muclibc -Wl,--gc-sections
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
 set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
 
+unset(COMPILE_FLAGS_FOR_SAMPLE_OPTIONS_FROM_ENV_VAR)
+if(${SAMPLE_OPTIONS_FROM_ENV_VAR})
+    set(COMPILE_FLAGS_FOR_SAMPLE_OPTIONS_FROM_ENV_VAR -DSAMPLE_OPTIONS_FROM_ENV_VAR)
+endif()
+
 unset(COMPILE_FLAGS_FOR_POOL_ALLOCATOR)
 if(${USE_POOL_ALLOCATOR_LIB})
     set(COMPILE_FLAGS_FOR_POOL_ALLOCATOR -DKVS_USE_POOL_ALLOCATOR)
@@ -56,6 +62,7 @@ set(${APP_NAME}_SRC
     source/mem_wrapper.c
     source/t31_video.c
     source/t31_audio.c
+    source/option_configuration.c
 )
 
 set(${APP_NAME}_INC
@@ -73,6 +80,7 @@ set_target_properties(${APP_NAME} PROPERTIES OUTPUT_NAME ${APP_NAME})
 target_compile_definitions(${APP_NAME} PUBLIC -D_XOPEN_SOURCE=600 -D_POSIX_C_SOURCE=200112L)
 target_compile_definitions(${APP_NAME} PUBLIC -DBUILD_EXECUTABLE_WITH_SHARED_LIBRARY)
 target_compile_definitions(${APP_NAME} PUBLIC ${COMPILE_FLAGS_FOR_POOL_ALLOCATOR})
+target_compile_definitions(${APP_NAME} PUBLIC ${COMPILE_FLAGS_FOR_SAMPLE_OPTIONS_FROM_ENV_VAR})
 target_include_directories(${APP_NAME} PUBLIC ${${APP_NAME}_INC})
 target_link_directories(${APP_NAME} PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/lib
@@ -105,6 +113,7 @@ set_target_properties(${APP_NAME}-static PROPERTIES OUTPUT_NAME ${APP_NAME}-stat
 target_compile_definitions(${APP_NAME}-static PUBLIC -D_XOPEN_SOURCE=600 -D_POSIX_C_SOURCE=200112L)
 target_compile_definitions(${APP_NAME}-static PUBLIC -DBUILD_EXECUTABLE_WITH_STATIC_LIBRARY)
 target_compile_definitions(${APP_NAME}-static PUBLIC ${COMPILE_FLAGS_FOR_POOL_ALLOCATOR})
+target_compile_definitions(${APP_NAME}-static PUBLIC ${COMPILE_FLAGS_FOR_SAMPLE_OPTIONS_FROM_ENV_VAR})
 target_include_directories(${APP_NAME}-static PUBLIC ${${APP_NAME}_INC})
 target_link_directories(${APP_NAME}-static PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/lib

--- a/samples/kvsapp-ingenic-t31/source/kvsappcli.c
+++ b/samples/kvsapp-ingenic-t31/source/kvsappcli.c
@@ -23,6 +23,7 @@
 #include "kvs/port.h"
 
 #include "sample_config.h"
+#include "option_configuration.h"
 #include "t31_video.h"
 #if ENABLE_AUDIO_TRACK
 #include "t31_audio.h"
@@ -73,11 +74,11 @@ static int setKvsAppOptions(KvsAppHandle kvsAppHandle)
         printf("Failed to set private key\r\n");
     }
 #else
-    if (KvsApp_setoption(kvsAppHandle, OPTION_AWS_ACCESS_KEY_ID, (const char *)AWS_ACCESS_KEY) != 0)
+    if (KvsApp_setoption(kvsAppHandle, OPTION_AWS_ACCESS_KEY_ID, OptCfg_getAwsAccessKey()) != 0)
     {
         printf("Failed to set AWS_ACCESS_KEY\r\n");
     }
-    if (KvsApp_setoption(kvsAppHandle, OPTION_AWS_SECRET_ACCESS_KEY, (const char *)AWS_SECRET_KEY) != 0)
+    if (KvsApp_setoption(kvsAppHandle, OPTION_AWS_SECRET_ACCESS_KEY, OptCfg_getAwsSecretAccessKey()) != 0)
     {
         printf("Failed to set AWS_SECRET_KEY\r\n");
     }
@@ -110,12 +111,16 @@ int main(int argc, char *argv[])
 {
     KvsAppHandle kvsAppHandle;
     uint64_t uLastPrintMemStatTimestamp = 0;
+    const char *pKvsStreamName = NULL;
 
 #ifdef KVS_USE_POOL_ALLOCATOR
     poolAllocatorInit((void *)pMemPool, sizeof(pMemPool));
 #endif
 
-    if ((kvsAppHandle = KvsApp_create(AWS_KVS_HOST, AWS_KVS_REGION, AWS_KVS_SERVICE, KVS_STREAM_NAME)) == NULL)
+    /* Resolve KVS stream name */
+    pKvsStreamName = (argc >= 2) ? argv[1] : KVS_STREAM_NAME;
+
+    if ((kvsAppHandle = KvsApp_create(OptCfg_getHostKinesisVideo(), OptCfg_getRegion(), OptCfg_getServiceKinesisVideo(), pKvsStreamName)) == NULL)
     {
         printf("Failed to initialize KVS\r\n");
     }

--- a/samples/kvsapp-ingenic-t31/source/option_configuration.c
+++ b/samples/kvsapp-ingenic-t31/source/option_configuration.c
@@ -1,0 +1,84 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "option_configuration.h"
+#include "sample_config.h"
+
+#define AWS_ACCESS_KEY_ENV_VAR          "AWS_ACCESS_KEY_ID"
+#define AWS_SECRET_KEY_ENV_VAR          "AWS_SECRET_ACCESS_KEY"
+#define AWS_DEFAULT_REGION_ENV_VAR      "AWS_DEFAULT_REGION"
+#define AWS_SESSION_TOKEN_ENV_VAR       "AWS_SESSION_TOKEN"
+
+#define AWS_KINESIS_VIDEO_HOST_ENV_VAR  "AWS_KVS_HOST"
+
+const char *OptCfg_getAwsAccessKey()
+{
+    char *pAwsAccessKey = NULL;
+
+#ifdef SAMPLE_OPTIONS_FROM_ENV_VAR
+    pAwsAccessKey = getenv(AWS_ACCESS_KEY_ENV_VAR);
+#endif /* SAMPLE_OPTIONS_FROM_ENV_VAR */
+
+    if (pAwsAccessKey == NULL)
+    {
+        pAwsAccessKey = AWS_ACCESS_KEY;
+    }
+
+    return pAwsAccessKey;
+}
+
+const char *OptCfg_getAwsSecretAccessKey()
+{
+    char *pAwsSecretAccessKey = NULL;
+
+#ifdef SAMPLE_OPTIONS_FROM_ENV_VAR
+    pAwsSecretAccessKey = getenv(AWS_SECRET_KEY_ENV_VAR);
+#endif /* SAMPLE_OPTIONS_FROM_ENV_VAR */
+
+    if (pAwsSecretAccessKey == NULL)
+    {
+        pAwsSecretAccessKey = AWS_SECRET_KEY;
+    }
+
+    return pAwsSecretAccessKey;
+}
+
+const char *OptCfg_getRegion()
+{
+    char *pRegion = NULL;
+
+#ifdef SAMPLE_OPTIONS_FROM_ENV_VAR
+    pRegion = getenv(AWS_DEFAULT_REGION_ENV_VAR);
+#endif /* SAMPLE_OPTIONS_FROM_ENV_VAR */
+
+    if (pRegion == NULL)
+    {
+        pRegion = AWS_KVS_REGION;
+    }
+
+    return pRegion;
+}
+
+const char *OptCfg_getServiceKinesisVideo()
+{
+    return "kinesisvideo";
+}
+
+const char *OptCfg_getHostKinesisVideo()
+{
+    char *pKvsHost = NULL;
+    const char *pRegion = NULL;
+    const char *pService = NULL;
+    size_t uLen = 0;
+
+#ifdef SAMPLE_OPTIONS_FROM_ENV_VAR
+    pKvsHost = getenv(AWS_KINESIS_VIDEO_HOST_ENV_VAR);
+#endif /* SAMPLE_OPTIONS_FROM_ENV_VAR */
+
+    if (pKvsHost == NULL)
+    {
+        pKvsHost = AWS_KVS_HOST;
+    }
+
+    return pKvsHost;
+}

--- a/samples/kvsapp/CMakeLists.txt
+++ b/samples/kvsapp/CMakeLists.txt
@@ -2,7 +2,13 @@ set(APP_NAME "kvsappcli")
 
 set(${APP_NAME}_SRC
     ${APP_NAME}.c
+    option_configuration.c
 )
+
+unset(COMPILE_FLAGS_FOR_SAMPLE_OPTIONS_FROM_ENV_VAR)
+if(${SAMPLE_OPTIONS_FROM_ENV_VAR})
+    set(COMPILE_FLAGS_FOR_SAMPLE_OPTIONS_FROM_ENV_VAR -DSAMPLE_OPTIONS_FROM_ENV_VAR)
+endif()
 
 unset(COMPILE_FLAGS_FOR_POOL_ALLOCATOR)
 if(${USE_POOL_ALLOCATOR_LIB})
@@ -30,6 +36,7 @@ if(${BUILD_SHARED_SAMPLES})
     target_compile_definitions(${APP_NAME} PUBLIC -DBUILD_EXECUTABLE_WITH_SHARED_LIBRARY)
     target_compile_definitions(${APP_NAME} PUBLIC ${COMPILE_FLAGS_FOR_POOL_ALLOCATOR})
     target_compile_definitions(${APP_NAME} PUBLIC ${COMPILE_FLAGS_FOR_SIGNAL_H})
+    target_compile_definitions(${APP_NAME} PUBLIC ${COMPILE_FLAGS_FOR_SAMPLE_OPTIONS_FROM_ENV_VAR})
     target_link_libraries(${APP_NAME}
         kvsapp-shared
         samplescommon-shared
@@ -45,6 +52,7 @@ if(${BUILD_STATIC_SAMPLES})
     target_compile_definitions(${APP_NAME}-static PUBLIC -DBUILD_EXECUTABLE_WITH_STATIC_LIBRARY)
     target_compile_definitions(${APP_NAME}-static PUBLIC ${COMPILE_FLAGS_FOR_POOL_ALLOCATOR})
     target_compile_definitions(${APP_NAME}-static PUBLIC ${COMPILE_FLAGS_FOR_SIGNAL_H})
+    target_compile_definitions(${APP_NAME}-static PUBLIC ${COMPILE_FLAGS_FOR_SAMPLE_OPTIONS_FROM_ENV_VAR})
     target_link_libraries(${APP_NAME}-static
         kvsapp-static
         samplescommon-static

--- a/samples/kvsapp/kvsappcli.c
+++ b/samples/kvsapp/kvsappcli.c
@@ -30,6 +30,7 @@
 
 #include "h264_file_loader.h"
 #include "sample_config.h"
+#include "option_configuration.h"
 
 #if ENABLE_AUDIO_TRACK
 #if USE_AUDIO_AAC_SAMPLE
@@ -202,11 +203,11 @@ static int setKvsAppOptions(KvsAppHandle kvsAppHandle)
         printf("Failed to set private key\r\n");
     }
 #else
-    if (KvsApp_setoption(kvsAppHandle, OPTION_AWS_ACCESS_KEY_ID, (const char *)AWS_ACCESS_KEY) != 0)
+    if (KvsApp_setoption(kvsAppHandle, OPTION_AWS_ACCESS_KEY_ID, OptCfg_getAwsAccessKey()) != 0)
     {
         printf("Failed to set AWS_ACCESS_KEY\r\n");
     }
-    if (KvsApp_setoption(kvsAppHandle, OPTION_AWS_SECRET_ACCESS_KEY, (const char *)AWS_SECRET_KEY) != 0)
+    if (KvsApp_setoption(kvsAppHandle, OPTION_AWS_SECRET_ACCESS_KEY, OptCfg_getAwsSecretAccessKey()) != 0)
     {
         printf("Failed to set AWS_SECRET_KEY\r\n");
     }
@@ -254,6 +255,7 @@ int main(int argc, char *argv[])
     ePutMediaFragmentAckEventType eAckEventType = eUnknown;
     uint64_t uFragmentTimecode = 0;
     unsigned int uErrorId = 0;
+    const char *pKvsStreamName = NULL;
 
 #ifdef KVS_USE_POOL_ALLOCATOR
     poolAllocatorInit((void *)pMemPool, sizeof(pMemPool));
@@ -287,7 +289,10 @@ int main(int argc, char *argv[])
 #endif /* USE_AUDIO_G711_SAMPLE */
 #endif /* ENABLE_AUDIO_TRACK */
 
-    if ((kvsAppHandle = KvsApp_create(AWS_KVS_HOST, AWS_KVS_REGION, AWS_KVS_SERVICE, KVS_STREAM_NAME)) == NULL)
+    /* Resolve KVS stream name */
+    pKvsStreamName = (argc >= 2) ? argv[1] : KVS_STREAM_NAME;
+
+    if ((kvsAppHandle = KvsApp_create(OptCfg_getHostKinesisVideo(), OptCfg_getRegion(), OptCfg_getServiceKinesisVideo(), pKvsStreamName)) == NULL)
     {
         printf("Failed to initialize KVS\r\n");
     }

--- a/samples/kvsapp/option_configuration.c
+++ b/samples/kvsapp/option_configuration.c
@@ -1,0 +1,84 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "option_configuration.h"
+#include "sample_config.h"
+
+#define AWS_ACCESS_KEY_ENV_VAR          "AWS_ACCESS_KEY_ID"
+#define AWS_SECRET_KEY_ENV_VAR          "AWS_SECRET_ACCESS_KEY"
+#define AWS_DEFAULT_REGION_ENV_VAR      "AWS_DEFAULT_REGION"
+#define AWS_SESSION_TOKEN_ENV_VAR       "AWS_SESSION_TOKEN"
+
+#define AWS_KINESIS_VIDEO_HOST_ENV_VAR  "AWS_KVS_HOST"
+
+const char *OptCfg_getAwsAccessKey()
+{
+    char *pAwsAccessKey = NULL;
+
+#ifdef SAMPLE_OPTIONS_FROM_ENV_VAR
+    pAwsAccessKey = getenv(AWS_ACCESS_KEY_ENV_VAR);
+#endif /* SAMPLE_OPTIONS_FROM_ENV_VAR */
+
+    if (pAwsAccessKey == NULL)
+    {
+        pAwsAccessKey = AWS_ACCESS_KEY;
+    }
+
+    return pAwsAccessKey;
+}
+
+const char *OptCfg_getAwsSecretAccessKey()
+{
+    char *pAwsSecretAccessKey = NULL;
+
+#ifdef SAMPLE_OPTIONS_FROM_ENV_VAR
+    pAwsSecretAccessKey = getenv(AWS_SECRET_KEY_ENV_VAR);
+#endif /* SAMPLE_OPTIONS_FROM_ENV_VAR */
+
+    if (pAwsSecretAccessKey == NULL)
+    {
+        pAwsSecretAccessKey = AWS_SECRET_KEY;
+    }
+
+    return pAwsSecretAccessKey;
+}
+
+const char *OptCfg_getRegion()
+{
+    char *pRegion = NULL;
+
+#ifdef SAMPLE_OPTIONS_FROM_ENV_VAR
+    pRegion = getenv(AWS_DEFAULT_REGION_ENV_VAR);
+#endif /* SAMPLE_OPTIONS_FROM_ENV_VAR */
+
+    if (pRegion == NULL)
+    {
+        pRegion = AWS_KVS_REGION;
+    }
+
+    return pRegion;
+}
+
+const char *OptCfg_getServiceKinesisVideo()
+{
+    return "kinesisvideo";
+}
+
+const char *OptCfg_getHostKinesisVideo()
+{
+    char *pKvsHost = NULL;
+    const char *pRegion = NULL;
+    const char *pService = NULL;
+    size_t uLen = 0;
+
+#ifdef SAMPLE_OPTIONS_FROM_ENV_VAR
+    pKvsHost = getenv(AWS_KINESIS_VIDEO_HOST_ENV_VAR);
+#endif /* SAMPLE_OPTIONS_FROM_ENV_VAR */
+
+    if (pKvsHost == NULL)
+    {
+        pKvsHost = AWS_KVS_HOST;
+    }
+
+    return pKvsHost;
+}

--- a/samples/kvsapp/option_configuration.h
+++ b/samples/kvsapp/option_configuration.h
@@ -1,0 +1,55 @@
+#ifndef SAMPLE_OPTIONS_H
+#define SAMPLE_OPTIONS_H
+
+/**
+ * @brief Get AWS access key
+ *
+ * It searches AWS access key with following order:
+ *      1. environment variable
+ *      2. sample_config.h
+ *
+ * @return AWS access key
+ */
+const char *OptCfg_getAwsAccessKey();
+
+/**
+ * @brief Get AWS secret access key
+ *
+ * It searches AWS secret access key with following order:
+ *      1. environment variable
+ *      2. sample_config.h
+ *
+ * @return AWS secret access key
+ */
+const char *OptCfg_getAwsSecretAccessKey();
+
+/**
+ * @brief Get AWS region
+ *
+ * It searches AWS region with following order:
+ *      1. environment variable
+ *      2. sample_config.h
+ *
+ * @return AWS region
+ */
+const char *OptCfg_getRegion();
+
+/**
+ * @brief Get AWS KVS service name
+ *
+ * @return KVS service name
+ */
+const char *OptCfg_getServiceKinesisVideo();
+
+/**
+ * @brief Get KVS host name
+ *
+ * It searches KVS host name with following order:
+ *      1. environment variable
+ *      2. sample_config.h
+ *
+ * @return KVS host name
+ */
+const char *OptCfg_getHostKinesisVideo();
+
+#endif /* SAMPLE_OPTIONS_H */


### PR DESCRIPTION
1. Support options configuration from environment and `sample_config.h`. It'll search environment first. It it's empty, then use configurations in `sample_config.h`.
2. Fix cmake version compatible issue in ingenic T31 sample.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
