### PR TITLE
Add callback when MKV data is sent to PUT MEDIA endpoint

### DIFF
--- a/app/kvsapp/include/kvs/kvsapp.h
+++ b/app/kvsapp/include/kvs/kvsapp.h
@@ -36,6 +36,16 @@ typedef struct KvsApp *KvsAppHandle;
  */
 typedef int (*OnDataFrameTerminateCallback_t)(uint8_t *pData, size_t uDataLen, uint64_t uTimestamp, TrackType_t xTrackType, void *pAppData);
 
+/**
+ * This callback is called whenever a data has been sent to PUT MEDIA endpoint. All data sent to PUT MEDIA endpoint follow MKV format, so it could
+ * help to debug which data has been sent.
+ *
+ * @param[in] pData Pointer of data
+ * @param[in] uDataLen Size of data
+ * @param[in] pAppData Pointer of application data that is assigned in function KvsApp_setOnMkvSentCallback()
+ */
+typedef int (*OnMkvSentCallback_t)(uint8_t *pData, size_t uDataLen, void *pAppData);
+
 typedef struct DataFrameCallbacks
 {
     OnDataFrameTerminateCallback_t onDataFrameTerminate;
@@ -145,5 +155,15 @@ int KvsApp_readFragmentAck(KvsAppHandle handle, ePutMediaFragmentAckEventType *p
  * @return Memory used in current stream buffer, zero value otherwise
  */
 size_t KvsApp_getStreamMemStatTotal(KvsAppHandle handle);
+
+/**
+ * Set onMkvSentCallback. Whenever a data has been sent to PUT MEDIA endpoint, it'll invoke this callback.
+ *
+ * @param handle KVS application handle
+ * @param onMkvSentCallback Callback
+ * @param pAppData The application data that will be passed in the argument of the callback
+ * @return 0 on success, non-zero value otherwise
+ */
+int KvsApp_setOnMkvSentCallback(KvsAppHandle handle, OnMkvSentCallback_t onMkvSentCallback, void *pAppData);
 
 #endif /* KVSAPP_H */

--- a/samples/kvsapp-ingenic-t31/include/sample_config.h
+++ b/samples/kvsapp-ingenic-t31/include/sample_config.h
@@ -32,6 +32,7 @@
 #define ENABLE_AUDIO_TRACK              1
 #define ENABLE_IOT_CREDENTIAL           0
 #define ENABLE_RING_BUFFER_MEM_LIMIT    1
+#define DEBUG_STORE_MEDIA_TO_FILE       0
 
 #define VIDEO_CODEC_NAME                "V_MPEG4/ISO/AVC"
 #define VIDEO_TRACK_NAME                "kvs video track"
@@ -114,5 +115,11 @@
 #define POOL_ALLOCATOR_SIZE     (BUFFER_MEM_LIMIT + POOL_ALLOCATOR_SIZE_FOR_KVS + POOL_ALLOCATOR_SIZE_FOR_APP)
 
 #endif /* KVS_USE_POOL_ALLOCATOR */
+
+/* Debug configuration */
+#if DEBUG_STORE_MEDIA_TO_FILE
+/* Store MKV content in a file with timestamp in its filename. */
+#define MEDIA_FILENAME_FORMAT                  "video_%" PRIu64 ".mkv"
+#endif /* DEBUG_STORE_MEDIA_TO_FILE */
 
 #endif /* SAMPLE_CONFIG_H */

--- a/samples/kvsapp/sample_config.h
+++ b/samples/kvsapp/sample_config.h
@@ -32,6 +32,7 @@
 #define ENABLE_AUDIO_TRACK              0
 #define ENABLE_IOT_CREDENTIAL           0
 #define ENABLE_RING_BUFFER_MEM_LIMIT    1
+#define DEBUG_STORE_MEDIA_TO_FILE       0
 
 /* Video configuration */
 #define H264_FILE_FORMAT                "../res/media/h264_annexb/frame-%03d.h264"
@@ -130,5 +131,11 @@
 #define POOL_ALLOCATOR_SIZE     (BUFFER_MEM_LIMIT + POOL_ALLOCATOR_SIZE_FOR_KVS + POOL_ALLOCATOR_SIZE_FOR_APP)
 
 #endif /* KVS_USE_POOL_ALLOCATOR */
+
+/* Debug configuration */
+#if DEBUG_STORE_MEDIA_TO_FILE
+/* Store MKV content in a file with timestamp in its filename. */
+#define MEDIA_FILENAME_FORMAT                  "video_%" PRIu64 ".mkv"
+#endif /* DEBUG_STORE_MEDIA_TO_FILE */
 
 #endif /* SAMPLE_CONFIG_H */


### PR DESCRIPTION
1. Add callback when MKV data is sent to PUT MEDIA endpoint
2. Add sample code that implements this callback and store the MKV data into a file
3. Change sample log EOL to '\n'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
