### PR TITLE
mkv: fix incompatible-pointer-types between Mkv_generatePcmCodecPrivateData and AudioTrackInfo_t.uCodecPrivateLen

### DIFF
--- a/src/include/kvs/mkv_generator.h
+++ b/src/include/kvs/mkv_generator.h
@@ -112,7 +112,7 @@ typedef struct AudioTrackInfo
     uint8_t uChannelNumber;
     uint8_t uBitsPerSample;
     uint8_t *pCodecPrivate;
-    uint32_t uCodecPrivateLen;
+    size_t uCodecPrivateLen;
 } AudioTrackInfo_t;
 
 /**


### PR DESCRIPTION
`Mkv_generatePcmCodecPrivateData` is taking `size_t*` but `AudioTrackInfo_t.uCodecPrivateLen` is `uint32_t`, which will cause following build warning in newer gcc:

```
warning: passing argument 5 of 'Mkv_generatePcmCodecPrivateData' from incompatible pointer type [-Wincompatible-pointer-types]
  353 |         Mkv_generatePcmCodecPrivateData(AUDIO_CODEC_OBJECT_TYPE, audioTrackInfo.uFrequency, audioTrackInfo.uChannelNumber, &audioTrackInfo.pCodecPrivate, &audioTrackInfo.uCodecPrivateLen);
      |                                                                                                                                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                                                                                                           |
      |                                                                                                                                                           uint32_t * {aka unsigned int *}
```

Signed-off-by: zhiqinli@amazon.com <zhiqinli@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
