### PR TITLE
add AWS_IOT prefix for IoT credential related macro and add support to read IoT credentials from ENV in kvsapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ Before running the example, you need to edit the file "*samples/kvsapp/sample_co
 
 #define H264_FILE_FORMAT                "/path/to/samples/h264SampleFrames/frame-%03d.h264"
 
-#define CREDENTIALS_HOST                "xxxxxxxxxxxxxx.credentials.iot.us-east-1.amazonaws.com"
-#define ROLE_ALIAS                      "KvsCameraIoTRoleAlias"
-#define THING_NAME                      KVS_STREAM_NAME
+#define AWS_IOT_CREDENTIALS_HOST                "xxxxxxxxxxxxxx.credentials.iot.us-east-1.amazonaws.com"
+#define AWS_IOT_ROLE_ALIAS                      "KvsCameraIoTRoleAlias"
+#define AWS_IOT_THING_NAME                      KVS_STREAM_NAME
 
-#define ROOT_CA \
+#define AWS_IOT_ROOT_CA \
 "-----BEGIN CERTIFICATE-----\n" \
 "......" \
 "-----END CERTIFICATE-----\n"
@@ -82,9 +82,9 @@ Before running the example, you need to edit the file "*samples/kvsapp/sample_co
 The values of these settings come from the procedure of setting up the credentials provider by following instructions in this document "[how-iot](https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/how-iot.html)".
 
 *   KVS_STREAM_NAME: It's the stream name.
-*   CREDENTIALS_HOST: It's the IoT credentials host we setup earier.
-*   ROLE_ALIAS: It's the role alias we setup earier.
-*   ROOT_CA, CERTIFICATE, PRIVATE_KEY: These are X509 certificates.  Please filled in your X509 certificates.
+*   AWS_IOT_CREDENTIALS_HOST: It's the IoT credentials host we setup earier.
+*   AWS_IOT_ROLE_ALIAS: It's the role alias we setup earier.
+*   AWS_IOT_ROOT_CA, CERTIFICATE, PRIVATE_KEY: These are X509 certificates.  Please filled in your X509 certificates.
 *   H264_FILE_FORMAT: It's H264 file location.
 
 ### Build and Run Example

--- a/samples/kvs-amebapro/README.md
+++ b/samples/kvs-amebapro/README.md
@@ -40,11 +40,11 @@ You also need to setup these settings. Please refer to linux example for more in
 #define AWS_KVS_SERVICE                 "kinesisvideo"
 #define AWS_KVS_HOST                    AWS_KVS_SERVICE "." AWS_KVS_REGION ".amazonaws.com"
 ...
-#define CREDENTIALS_HOST                "xxxxxxxxxxxxxx.credentials.iot.us-east-1.amazonaws.com"
-#define ROLE_ALIAS                      "KvsCameraIoTRoleAlias"
-#define THING_NAME                      KVS_STREAM_NAME
+#define AWS_IOT_CREDENTIALS_HOST                "xxxxxxxxxxxxxx.credentials.iot.us-east-1.amazonaws.com"
+#define AWS_IOT_ROLE_ALIAS                      "KvsCameraIoTRoleAlias"
+#define AWS_IOT_THING_NAME                      KVS_STREAM_NAME
 
-#define ROOT_CA \
+#define AWS_IOT_ROOT_CA \
 "-----BEGIN CERTIFICATE-----\n" \
 "......" \
 "-----END CERTIFICATE-----\n"

--- a/samples/kvs-amebapro/kvs_producer.c
+++ b/samples/kvs-amebapro/kvs_producer.c
@@ -587,10 +587,10 @@ static int kvsInitialize(Kvs_t *pKvs)
         pKvs->xPutMediaPara.xTimecodeType = TIMECODE_TYPE_ABSOLUTE;
 
 #if ENABLE_IOT_CREDENTIAL
-        pKvs->xIotCredentialReq.pCredentialHost = CREDENTIALS_HOST;
-        pKvs->xIotCredentialReq.pRoleAlias = ROLE_ALIAS;
-        pKvs->xIotCredentialReq.pThingName = THING_NAME;
-        pKvs->xIotCredentialReq.pRootCA = ROOT_CA;
+        pKvs->xIotCredentialReq.pCredentialHost = AWS_IOT_CREDENTIALS_HOST;
+        pKvs->xIotCredentialReq.pRoleAlias = AWS_IOT_ROLE_ALIAS;
+        pKvs->xIotCredentialReq.pThingName = AWS_IOT_THING_NAME;
+        pKvs->xIotCredentialReq.pRootCA = AWS_IOT_ROOT_CA;
         pKvs->xIotCredentialReq.pCertificate = CERTIFICATE;
         pKvs->xIotCredentialReq.pPrivateKey = PRIVATE_KEY;
 #endif

--- a/samples/kvs-amebapro/sample_config.h
+++ b/samples/kvs-amebapro/sample_config.h
@@ -44,11 +44,11 @@
 
 /* IoT credential configuration */
 #if ENABLE_IOT_CREDENTIAL
-#define CREDENTIALS_HOST                "xxxxxxxxxxxxxx.credentials.iot.us-east-1.amazonaws.com"
-#define ROLE_ALIAS                      "KvsCameraIoTRoleAlias"
-#define THING_NAME                      KVS_STREAM_NAME
+#define AWS_IOT_CREDENTIALS_HOST                "xxxxxxxxxxxxxx.credentials.iot.us-east-1.amazonaws.com"
+#define AWS_IOT_ROLE_ALIAS                      "KvsCameraIoTRoleAlias"
+#define AWS_IOT_THING_NAME                      KVS_STREAM_NAME
 
-#define ROOT_CA \
+#define AWS_IOT_ROOT_CA \
 "-----BEGIN CERTIFICATE-----\n" \
 "......\n" \
 "-----END CERTIFICATE-----\n"

--- a/samples/kvs-esp32/main/kvs_esp32.c
+++ b/samples/kvs-esp32/main/kvs_esp32.c
@@ -184,19 +184,19 @@ static int setKvsAppOptions(KvsAppHandle kvsAppHandle)
 
     /* Setup credentials, it should be either using IoT credentials or AWS access key. */
 #if ENABLE_IOT_CREDENTIAL
-    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_CREDENTIAL_HOST, (const char *)CREDENTIALS_HOST) != 0)
+    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_CREDENTIAL_HOST, (const char *)AWS_IOT_CREDENTIALS_HOST) != 0)
     {
         printf("Failed to set credential host\n");
     }
-    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_ROLE_ALIAS, (const char *)ROLE_ALIAS) != 0)
+    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_ROLE_ALIAS, (const char *)AWS_IOT_ROLE_ALIAS) != 0)
     {
         printf("Failed to set role alias\n");
     }
-    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_THING_NAME, (const char *)THING_NAME) != 0)
+    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_THING_NAME, (const char *)AWS_IOT_THING_NAME) != 0)
     {
         printf("Failed to set thing name\n");
     }
-    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_X509_ROOTCA, (const char *)ROOT_CA) != 0)
+    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_X509_ROOTCA, (const char *)AWS_IOT_ROOT_CA) != 0)
     {
         printf("Failed to set root CA\n");
     }

--- a/samples/kvs-esp32/main/sample_config.h
+++ b/samples/kvs-esp32/main/sample_config.h
@@ -79,11 +79,11 @@
 
 /* IoT credential configuration */
 #if ENABLE_IOT_CREDENTIAL
-#define CREDENTIALS_HOST                "xxxxxxxxxxxxxx.credentials.iot.us-east-1.amazonaws.com"
-#define ROLE_ALIAS                      "KvsCameraIoTRoleAlias"
-#define THING_NAME                      KVS_STREAM_NAME
+#define AWS_IOT_CREDENTIALS_HOST                "xxxxxxxxxxxxxx.credentials.iot.us-east-1.amazonaws.com"
+#define AWS_IOT_ROLE_ALIAS                      "KvsCameraIoTRoleAlias"
+#define AWS_IOT_THING_NAME                      KVS_STREAM_NAME
 
-#define ROOT_CA \
+#define AWS_IOT_ROOT_CA \
 "-----BEGIN CERTIFICATE-----\n" \
 "......\n" \
 "-----END CERTIFICATE-----\n"

--- a/samples/kvs-with-webrtc/kvsappcli.c
+++ b/samples/kvs-with-webrtc/kvsappcli.c
@@ -42,19 +42,19 @@ static int setKvsAppOptions(KvsAppHandle kvsAppHandle)
 
     /* Setup credentials, it should be either using IoT credentials or AWS access key. */
 #if ENABLE_IOT_CREDENTIAL
-    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_CREDENTIAL_HOST, (const char *)CREDENTIALS_HOST) != 0)
+    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_CREDENTIAL_HOST, (const char *)AWS_IOT_CREDENTIALS_HOST) != 0)
     {
         printf("Failed to set credential host\n");
     }
-    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_ROLE_ALIAS, (const char *)ROLE_ALIAS) != 0)
+    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_ROLE_ALIAS, (const char *)AWS_IOT_ROLE_ALIAS) != 0)
     {
         printf("Failed to set role alias\n");
     }
-    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_THING_NAME, (const char *)THING_NAME) != 0)
+    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_THING_NAME, (const char *)AWS_IOT_THING_NAME) != 0)
     {
         printf("Failed to set thing name\n");
     }
-    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_X509_ROOTCA, (const char *)ROOT_CA) != 0)
+    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_X509_ROOTCA, (const char *)AWS_IOT_ROOT_CA) != 0)
     {
         printf("Failed to set root CA\n");
     }

--- a/samples/kvs-with-webrtc/sample_config.h
+++ b/samples/kvs-with-webrtc/sample_config.h
@@ -61,11 +61,11 @@
 
 /* IoT credential configuration */
 #if ENABLE_IOT_CREDENTIAL
-#define CREDENTIALS_HOST                "xxxxxxxxxxxxxx.credentials.iot.us-east-1.amazonaws.com"
-#define ROLE_ALIAS                      "KvsCameraIoTRoleAlias"
-#define THING_NAME                      KVS_STREAM_NAME
+#define AWS_IOT_CREDENTIALS_HOST                "xxxxxxxxxxxxxx.credentials.iot.us-east-1.amazonaws.com"
+#define AWS_IOT_ROLE_ALIAS                      "KvsCameraIoTRoleAlias"
+#define AWS_IOT_THING_NAME                      KVS_STREAM_NAME
 
-#define ROOT_CA \
+#define AWS_IOT_ROOT_CA \
 "-----BEGIN CERTIFICATE-----\n" \
 "......\n" \
 "-----END CERTIFICATE-----\n"

--- a/samples/kvsapp-ingenic-t31/include/sample_config.h
+++ b/samples/kvsapp-ingenic-t31/include/sample_config.h
@@ -63,11 +63,11 @@
 
 /* IoT credential configuration */
 #if ENABLE_IOT_CREDENTIAL
-#define CREDENTIALS_HOST                "xxxxxxxxxxxxxx.credentials.iot.us-east-1.amazonaws.com"
-#define ROLE_ALIAS                      "KvsCameraIoTRoleAlias"
-#define THING_NAME                      KVS_STREAM_NAME
+#define AWS_IOT_CREDENTIALS_HOST                "xxxxxxxxxxxxxx.credentials.iot.us-east-1.amazonaws.com"
+#define AWS_IOT_ROLE_ALIAS                      "KvsCameraIoTRoleAlias"
+#define AWS_IOT_THING_NAME                      KVS_STREAM_NAME
 
-#define ROOT_CA \
+#define AWS_IOT_ROOT_CA \
 "-----BEGIN CERTIFICATE-----\n" \
 "......\n" \
 "-----END CERTIFICATE-----\n"

--- a/samples/kvsapp-ingenic-t31/source/kvsappcli.c
+++ b/samples/kvsapp-ingenic-t31/source/kvsappcli.c
@@ -79,19 +79,19 @@ static int setKvsAppOptions(KvsAppHandle kvsAppHandle)
 
     /* Setup credentials, it should be either using IoT credentials or AWS access key. */
 #if ENABLE_IOT_CREDENTIAL
-    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_CREDENTIAL_HOST, (const char *)CREDENTIALS_HOST) != 0)
+    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_CREDENTIAL_HOST, (const char *)AWS_IOT_CREDENTIALS_HOST) != 0)
     {
         printf("Failed to set credential host\n");
     }
-    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_ROLE_ALIAS, (const char *)ROLE_ALIAS) != 0)
+    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_ROLE_ALIAS, (const char *)AWS_IOT_ROLE_ALIAS) != 0)
     {
         printf("Failed to set role alias\n");
     }
-    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_THING_NAME, (const char *)THING_NAME) != 0)
+    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_THING_NAME, (const char *)AWS_IOT_THING_NAME) != 0)
     {
         printf("Failed to set thing name\n");
     }
-    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_X509_ROOTCA, (const char *)ROOT_CA) != 0)
+    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_X509_ROOTCA, (const char *)AWS_IOT_ROOT_CA) != 0)
     {
         printf("Failed to set root CA\n");
     }

--- a/samples/kvsapp/kvsappcli.c
+++ b/samples/kvsapp/kvsappcli.c
@@ -233,27 +233,27 @@ static int setKvsAppOptions(KvsAppHandle kvsAppHandle)
 
     /* Setup credentials, it should be either using IoT credentials or AWS access key. */
 #if ENABLE_IOT_CREDENTIAL
-    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_CREDENTIAL_HOST, (const char *)CREDENTIALS_HOST) != 0)
+    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_CREDENTIAL_HOST, OptCfg_getHostIotCredentials()) != 0)
     {
         printf("Failed to set credential host\n");
     }
-    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_ROLE_ALIAS, (const char *)ROLE_ALIAS) != 0)
+    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_ROLE_ALIAS, OptCfg_getIotRoleAlias()) != 0)
     {
         printf("Failed to set role alias\n");
     }
-    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_THING_NAME, (const char *)THING_NAME) != 0)
+    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_THING_NAME, OptCfg_getIotThingName()) != 0)
     {
         printf("Failed to set thing name\n");
     }
-    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_X509_ROOTCA, (const char *)ROOT_CA) != 0)
+    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_X509_ROOTCA, (const char *)AWS_IOT_ROOT_CA) != 0)
     {
         printf("Failed to set root CA\n");
     }
-    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_X509_CERT, (const char *)CERTIFICATE) != 0)
+    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_X509_CERT, (const char *)AWS_IOT_CERTIFICATE) != 0)
     {
         printf("Failed to set certificate\n");
     }
-    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_X509_KEY, (const char *)PRIVATE_KEY) != 0)
+    if (KvsApp_setoption(kvsAppHandle, OPTION_IOT_X509_KEY, (const char *)AWS_IOT_PRIVATE_KEY) != 0)
     {
         printf("Failed to set private key\n");
     }

--- a/samples/kvsapp/option_configuration.c
+++ b/samples/kvsapp/option_configuration.c
@@ -20,12 +20,21 @@
 #include "option_configuration.h"
 #include "sample_config.h"
 
-#define AWS_ACCESS_KEY_ENV_VAR          "AWS_ACCESS_KEY_ID"
-#define AWS_SECRET_KEY_ENV_VAR          "AWS_SECRET_ACCESS_KEY"
-#define AWS_SESSION_TOKEN_ENV_VAR       "AWS_SESSION_TOKEN"
-#define AWS_DEFAULT_REGION_ENV_VAR      "AWS_DEFAULT_REGION"
+#ifdef SAMPLE_OPTIONS_FROM_ENV_VAR
 
-#define AWS_KINESIS_VIDEO_HOST_ENV_VAR  "AWS_KVS_HOST"
+#define AWS_ACCESS_KEY_ENV_VAR "AWS_ACCESS_KEY_ID"
+#define AWS_SECRET_KEY_ENV_VAR "AWS_SECRET_ACCESS_KEY"
+#define AWS_SESSION_TOKEN_ENV_VAR "AWS_SESSION_TOKEN"
+#define AWS_DEFAULT_REGION_ENV_VAR "AWS_DEFAULT_REGION"
+#define AWS_KINESIS_VIDEO_HOST_ENV_VAR "AWS_KVS_HOST"
+
+#if ENABLE_IOT_CREDENTIAL
+#define AWS_IOT_CREDENTIALS_HOST_ENV_VAR "AWS_IOT_CREDENTIALS_HOST"
+#define AWS_IOT_ROLE_ALIAS_ENV_VAR "AWS_IOT_ROLE_ALIAS"
+#define AWS_IOT_THING_NAME_ENV_VAR "AWS_IOT_THING_NAME"
+#endif /* ENABLE_IOT_CREDENTIAL */
+
+#endif /* SAMPLE_OPTIONS_FROM_ENV_VAR */
 
 const char *OptCfg_getAwsAccessKey()
 {
@@ -99,9 +108,6 @@ const char *OptCfg_getServiceKinesisVideo()
 const char *OptCfg_getHostKinesisVideo()
 {
     char *pKvsHost = NULL;
-    const char *pRegion = NULL;
-    const char *pService = NULL;
-    size_t uLen = 0;
 
 #ifdef SAMPLE_OPTIONS_FROM_ENV_VAR
     pKvsHost = getenv(AWS_KINESIS_VIDEO_HOST_ENV_VAR);
@@ -114,3 +120,55 @@ const char *OptCfg_getHostKinesisVideo()
 
     return pKvsHost;
 }
+
+#if ENABLE_IOT_CREDENTIAL
+
+const char *OptCfg_getHostIotCredentials()
+{
+    char *pIotCredentialsHost = NULL;
+
+#ifdef SAMPLE_OPTIONS_FROM_ENV_VAR
+    pIotCredentialsHost = getenv(AWS_IOT_CREDENTIALS_HOST_ENV_VAR);
+#endif /* SAMPLE_OPTIONS_FROM_ENV_VAR */
+
+    if (pIotCredentialsHost == NULL)
+    {
+        pIotCredentialsHost = AWS_IOT_CREDENTIALS_HOST;
+    }
+
+    return pIotCredentialsHost;
+}
+
+const char *OptCfg_getIotRoleAlias()
+{
+    char *pIotRoleAlias = NULL;
+
+#ifdef SAMPLE_OPTIONS_FROM_ENV_VAR
+    pIotRoleAlias = getenv(AWS_IOT_ROLE_ALIAS_ENV_VAR);
+#endif /* SAMPLE_OPTIONS_FROM_ENV_VAR */
+
+    if (pIotRoleAlias == NULL)
+    {
+        pIotRoleAlias = AWS_IOT_ROLE_ALIAS;
+    }
+
+    return pIotRoleAlias;
+}
+
+const char *OptCfg_getIotThingName()
+{
+    char *pIotThingName = NULL;
+
+#ifdef SAMPLE_OPTIONS_FROM_ENV_VAR
+    pIotThingName = getenv(AWS_IOT_THING_NAME_ENV_VAR);
+#endif /* SAMPLE_OPTIONS_FROM_ENV_VAR */
+
+    if (pIotThingName == NULL)
+    {
+        pIotThingName = AWS_IOT_THING_NAME;
+    }
+
+    return pIotThingName;
+}
+
+#endif /* ENABLE_IOT_CREDENTIAL */

--- a/samples/kvsapp/sample_config.h
+++ b/samples/kvsapp/sample_config.h
@@ -64,21 +64,21 @@
 
 /* IoT credential configuration */
 #if ENABLE_IOT_CREDENTIAL
-#define CREDENTIALS_HOST                "xxxxxxxxxxxxxx.credentials.iot.us-east-1.amazonaws.com"
-#define ROLE_ALIAS                      "KvsCameraIoTRoleAlias"
-#define THING_NAME                      KVS_STREAM_NAME
+#define AWS_IOT_CREDENTIALS_HOST                "xxxxxxxxxxxxxx.credentials.iot.us-east-1.amazonaws.com"
+#define AWS_IOT_ROLE_ALIAS                      "KvsCameraIoTRoleAlias"
+#define AWS_IOT_THING_NAME                      KVS_STREAM_NAME
 
-#define ROOT_CA \
+#define AWS_IOT_ROOT_CA \
 "-----BEGIN CERTIFICATE-----\n" \
 "......\n" \
 "-----END CERTIFICATE-----\n"
 
-#define CERTIFICATE \
+#define AWS_IOT_CERTIFICATE \
 "-----BEGIN CERTIFICATE-----\n" \
 "......\n" \
 "-----END CERTIFICATE-----\n"
 
-#define PRIVATE_KEY \
+#define AWS_IOT_PRIVATE_KEY \
 "-----BEGIN RSA PRIVATE KEY-----\n" \
 "......\n" \
 "-----END RSA PRIVATE KEY-----\n"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
add AWS_IOT prefix for IoT credential related macro
add support to read IoT credentials from ENV in kvsapp

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
