### PR TITLE
ci: avoid using gcc-11 for a known mbedtls build issue

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -10,6 +10,8 @@ env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
   PARALLEL_LEVEL: 16
+  CC: gcc-10
+  CXX: g++-10
 
 jobs:
   build:


### PR DESCRIPTION
*Issue #, if available:*
See this [build error](https://github.com/aws-samples/amazon-kinesis-video-streams-producer-embedded-c/actions/runs/4899356565/jobs/8749259765?pr=75#step:4:91)

This compatible issue will impact current CI build check.

*Description of changes:*
Avoid this build error by specifying gcc-10.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
