### PR TITLE
adding initial fragment metadata tags

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,7 +19,7 @@ jobs:
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,7 +19,7 @@ jobs:
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-22
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2

--- a/src/include/kvs/mkv_generator.h
+++ b/src/include/kvs/mkv_generator.h
@@ -38,6 +38,22 @@
 
 #define MKV_TRACK_SIZE          ( 2 )
 
+
+#define MAX_TAG_NAME_LEN    128
+#define MAX_TAG_VALUE_LEN   256
+
+//https://github.com/awslabs/amazon-kinesis-video-streams-pic/blob/c98c2a256a7bb3dfc4db41ae26d45e28ac7eec56/src/mkvgen/include/com/amazonaws/kinesis/video/mkvgen/Include.h#L99
+//https://github.com/awslabs/amazon-kinesis-video-streams-pic/blob/c98c2a256a7bb3dfc4db41ae26d45e28ac7eec56/src/mkvgen/include/com/amazonaws/kinesis/video/mkvgen/Include.h#L104C31-L104C34
+
+typedef struct {
+
+    char key[MAX_TAG_NAME_LEN];
+    char value[MAX_TAG_VALUE_LEN];
+
+} MkvTag_t;
+
+
+
 typedef enum TrackType
 {
     TRACK_VIDEO = 1,
@@ -212,5 +228,13 @@ int Mkv_generateAacCodecPrivateData(Mpeg4AudioObjectTypes_t objectType, uint32_t
  * @return 0 on success, non-zero value otherwise
  */
 int Mkv_generatePcmCodecPrivateData(PcmFormatCode_t format, uint32_t uSamplingRate, uint16_t channels, uint8_t **ppCodecPrivateData, size_t *puCodecPrivateDataLen);
+
+
+
+int Mkv_initializeTagsHdr(uint8_t *pTagHdr,
+                          size_t uTagHdrLen,
+                          uint32_t numTags,
+                          const MkvTag_t *tags);
+
 
 #endif /* KVS_MKV_GENERATOR_H */


### PR DESCRIPTION
*Issue #, if available:*
Close  https://github.com/aws-samples/amazon-kinesis-video-streams-producer-embedded-c/issues/87 
New feature support prep for the  Metadata tags w/MKV tags
*Description of changes:*
Adding the MKV tag support ( app integration will follow next)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Logic to test/add tags within the MKV 
```
int Kvs_dataFrameGetContent(DataFrameHandle xDataFrameHandle,
                            uint8_t **ppMkvHeader,
                            size_t *puMkvHeaderLen,
                            uint8_t **ppData,
                            size_t *puDataLen)
{
    int res = KVS_ERRNO_NONE;
    DataFrame_t *pxDataFrame = xDataFrameHandle;
    static bool firstClusterSeen = false;
    static uint32_t clusterCount = 0;
    static uint32_t tagCounter = 1;

    // Input validation
    if (pxDataFrame == NULL || ppMkvHeader == NULL ||
        puMkvHeaderLen == NULL || ppData == NULL || puDataLen == NULL) {
        LogError("Invalid argument in Kvs_dataFrameGetContent");
        return KVS_ERROR_INVALID_ARGUMENT;
    }

    // Track cluster transitions
    if (pxDataFrame->xDataFrameIn.xClusterType == MKV_CLUSTER) {
        if (!firstClusterSeen) {
            firstClusterSeen = true;
            clusterCount++;
            LogDebug("First cluster detected");
        } else {
            clusterCount++;
            LogInfo("Cluster #%u detected - Adding tags before cluster", clusterCount);

            // Define tags with exact sizes
            MkvTag_t tags[1];
            memset(tags, 0, sizeof(tags));

            const char* tagKey = "TEST_KEY_1D";
            size_t keyLen = strlen(tagKey);

            char tagValue[32];
            int valueLen = snprintf(tagValue, sizeof(tagValue), "TEST_VALUE_%uD", tagCounter++);
            if (valueLen < 0 || valueLen >= sizeof(tagValue)) {
                LogError("Tag value too long");
                return KVS_ERROR_INVALID_ARGUMENT;
            }

            // Copy strings without null terminators for MKV content
            memcpy(tags[0].key, tagKey, keyLen);
            memcpy(tags[0].value, tagValue, valueLen);

            // Get the original header information
            uint8_t *originalHeader = (uint8_t *)pxDataFrame->pMkvHdr;
            size_t originalHeaderLen = pxDataFrame->uMkvHdrLen;

            LogDebug("Original header - Address: %p, Length: %zu",
                     (void*)originalHeader, originalHeaderLen);

            // Calculate exact tag structure size

            size_t tagStructSize = 4 + 8 +    // Tags element header
                                   2 + 8 +    // Tag element header
                                   2 + 8 +    // SimpleTag element header
                                   2 + 8 + keyLen +    // TagName element header and content
                                   2 + 8 + valueLen;   // TagString element header and content


            // Allocate new buffer with the exact size needed
            size_t newHeaderLen = tagStructSize + originalHeaderLen;
            uint8_t *newHeader = (uint8_t *)malloc(newHeaderLen);
            if (newHeader == NULL) {
                LogError("Failed to allocate memory for new header");
                return KVS_ERROR_OUT_OF_MEMORY;
            }

            // Initialize tags at the start of the buffer
            res = Mkv_initializeTagsHdr(newHeader,
                                        tagStructSize,  // Exact size
                                        1,             // One tag
                                        tags);

            if (res != KVS_ERRNO_NONE) {
                LogError("Failed to add MKV tags, error: %d", res);
                free(newHeader);
                return res;
            }

            // Copy cluster data after the tags
            memcpy(newHeader + tagStructSize,
                   originalHeader,
                   originalHeaderLen);

            // Update the frame's header information
            pxDataFrame->pMkvHdr = (char *)newHeader;
            pxDataFrame->uMkvHdrLen = newHeaderLen;

            LogInfo("MKV tags added successfully before cluster #%u. New header size: %zu",
                    clusterCount, pxDataFrame->uMkvHdrLen);

            // Debug: Print first 64 bytes of the new header
            LogDebug("New header content (first 64 bytes):");
            for (size_t i = 0; i < 64 && i < pxDataFrame->uMkvHdrLen; i++) {
                printf("%02x ", newHeader[i]);
                if ((i + 1) % 16 == 0) printf("\n");
            }
            printf("\n");
        }
    }

    // Assign frame content
    *ppMkvHeader = (uint8_t *)(pxDataFrame->pMkvHdr);
    *puMkvHeaderLen = pxDataFrame->uMkvHdrLen;
    *ppData = (uint8_t *)(pxDataFrame->xDataFrameIn.pData);
    *puDataLen = pxDataFrame->xDataFrameIn.uDataLen;

    return res;
}
```
