### PR TITLE
Add fragmentmetadata to the kvsappcli application, CI, fix build and runtime issues for Mac

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -26,6 +26,11 @@ jobs:
       with:
         submodules: 'recursive'
 
+    - name: Setup cmake
+      uses: jwlawson/actions-setup-cmake@v2
+      with:
+        cmake-version: '3.x'
+
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,7 +19,7 @@ jobs:
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/kvsappcli.yaml
+++ b/.github/workflows/kvsappcli.yaml
@@ -29,6 +29,11 @@ jobs:
           brew install coreutils # for gtimeout 
           brew install --cask mkvtoolnix
 
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
+
       - name: Fix the const issue
         working-directory: ./libraries/amazon/amazon-kinesis-video-streams-media-interface
         run: |
@@ -45,7 +50,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: us-west-2
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-to-assume: ${{ secrets.KVS_GITHUB_ACTIONS_ROLE_ARN }}
 
       - name: Run the sample
         working-directory: ./build

--- a/.github/workflows/kvsappcli.yaml
+++ b/.github/workflows/kvsappcli.yaml
@@ -1,0 +1,70 @@
+name: kvsappcli test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  kvsappcli-on-mac:
+    runs-on: macos-15
+
+    permissions:
+      id-token: write
+      contents: read
+
+    env:
+      STREAM_NAME: kvs-producer-embedded-c-kvsappcli-macos
+      AWS_KVS_HOST: "kinesisvideo.us-west-2.amazonaws.com"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
+      - name: Install dependencies
+        run: |
+          brew update
+          brew install coreutils # for gtimeout 
+          brew install --cask mkvtoolnix
+
+      - name: Fix the const issue
+        working-directory: ./libraries/amazon/amazon-kinesis-video-streams-media-interface
+        run: |
+          git apply ../../../patches/amazon-kinesis-video-streams-media-interface/const-fix.patch
+
+      - name: Build project
+        run: |
+          mkdir build
+          cd build
+          cmake .. -DCMAKE_BUILD_TYPE="Debug" -DENABLE_MKV_DUMP=ON
+          make -j
+
+      - name: Setup AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+
+      - name: Run the sample
+        working-directory: ./build
+        run: |
+          gtimeout --signal=SIGINT --kill-after=15s --preserve-status 30s ./bin/kvsappcli "$STREAM_NAME"
+
+      - name: Check MKV file
+        working-directory: ./build
+        run: |
+          if [ ! -f ./dumped_output.mkv ]; then
+            echo "❌ MKV file was not created!"
+            exit 1
+          fi
+          
+          output="$(mkvinfo -v ./dumped_output.mkv)"
+          echo "$output"
+      
+          if ! echo "$output" | grep "String: test_value_9"; then
+            echo "❌ No metadata found!"
+            exit 1
+          fi
+        shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
+cmake-build-debug
 
 samples/kvs-esp32/sdkconfig.old
 samples/kvs-esp32/components/llhttp/*

--- a/patches/amazon-kinesis-video-streams-media-interface/const-fix.patch
+++ b/patches/amazon-kinesis-video-streams-media-interface/const-fix.patch
@@ -1,0 +1,183 @@
+diff --git a/include/com/amazonaws/kinesis/video/capturer/AudioCapturer.h b/include/com/amazonaws/kinesis/video/capturer/AudioCapturer.h
+index e0747f4..63d0c79 100644
+--- a/include/com/amazonaws/kinesis/video/capturer/AudioCapturer.h
++++ b/include/com/amazonaws/kinesis/video/capturer/AudioCapturer.h
+@@ -46,7 +46,7 @@ AudioCapturerHandle audioCapturerCreate(void);
+  * @param[in] handle Handle of AudioCapturer.
+  * @return AudioCapturerStatus
+  */
+-AudioCapturerStatus audioCapturerGetStatus(const AudioCapturerHandle const handle);
++AudioCapturerStatus audioCapturerGetStatus(const AudioCapturerHandle handle);
+ 
+ /**
+  * @brief Get capturer capability.
+@@ -55,7 +55,7 @@ AudioCapturerStatus audioCapturerGetStatus(const AudioCapturerHandle const handl
+  * @param[out] pCapability Capturer capability.
+  * @return int 0 or error code.
+  */
+-int audioCapturerGetCapability(const AudioCapturerHandle const handle, AudioCapability* pCapability);
++int audioCapturerGetCapability(const AudioCapturerHandle handle, AudioCapability* pCapability);
+ 
+ /**
+  * @brief Set capturer format, channel number, bit depth and sample rate.
+@@ -80,7 +80,7 @@ int audioCapturerSetFormat(AudioCapturerHandle handle, const AudioFormat format,
+  * @param[in] pBitDepth Frame bit depth.
+  * @return int 0 or error code.
+  */
+-int audioCapturerGetFormat(const AudioCapturerHandle const handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
++int audioCapturerGetFormat(const AudioCapturerHandle handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
+                            AudioBitDepth* pBitDepth);
+ 
+ /**
+diff --git a/include/com/amazonaws/kinesis/video/capturer/VideoCapturer.h b/include/com/amazonaws/kinesis/video/capturer/VideoCapturer.h
+index 0b3671f..412625a 100644
+--- a/include/com/amazonaws/kinesis/video/capturer/VideoCapturer.h
++++ b/include/com/amazonaws/kinesis/video/capturer/VideoCapturer.h
+@@ -46,7 +46,7 @@ VideoCapturerHandle videoCapturerCreate(void);
+  * @param[in] handle Handle of VideoCapturer.
+  * @return VideoCapturerStatus Status of VideoCapturer.
+  */
+-VideoCapturerStatus videoCapturerGetStatus(const VideoCapturerHandle const handle);
++VideoCapturerStatus videoCapturerGetStatus(const VideoCapturerHandle handle);
+ 
+ /**
+  * @brief Get capturer capability.
+@@ -55,7 +55,7 @@ VideoCapturerStatus videoCapturerGetStatus(const VideoCapturerHandle const handl
+  * @param[out] pCapability Capturer capability.
+  * @return int 0 or error code.
+  */
+-int videoCapturerGetCapability(const VideoCapturerHandle const handle, VideoCapability* pCapability);
++int videoCapturerGetCapability(const VideoCapturerHandle handle, VideoCapability* pCapability);
+ 
+ /**
+  * @brief Set capturer format and resolution.
+@@ -75,7 +75,7 @@ int videoCapturerSetFormat(VideoCapturerHandle handle, const VideoFormat format,
+  * @param[out] pResolution Frame resolution.
+  * @return int 0 or error code.
+  */
+-int videoCapturerGetFormat(const VideoCapturerHandle const handle, VideoFormat* pFormat, VideoResolution* pResolution);
++int videoCapturerGetFormat(const VideoCapturerHandle handle, VideoFormat* pFormat, VideoResolution* pResolution);
+ 
+ /**
+  * @brief Acquire and turn on video stream.
+diff --git a/include/com/amazonaws/kinesis/video/player/AudioPlayer.h b/include/com/amazonaws/kinesis/video/player/AudioPlayer.h
+index db15477..2bf1c51 100644
+--- a/include/com/amazonaws/kinesis/video/player/AudioPlayer.h
++++ b/include/com/amazonaws/kinesis/video/player/AudioPlayer.h
+@@ -46,7 +46,7 @@ AudioPlayerHandle audioPlayerCreate(void);
+  * @param[in] handle Handle of AudioPlayer.
+  * @return AudioPlayerStatus Status of AudioPlayer.
+  */
+-AudioPlayerStatus audioPlayerGetStatus(const AudioPlayerHandle const handle);
++AudioPlayerStatus audioPlayerGetStatus(const AudioPlayerHandle handle);
+ 
+ /**
+  * @brief Get player capability.
+@@ -55,7 +55,7 @@ AudioPlayerStatus audioPlayerGetStatus(const AudioPlayerHandle const handle);
+  * @param[out] pCapability Player capability.
+  * @return int 0 or error code.
+  */
+-int audioPlayerGetCapability(const AudioPlayerHandle const handle, AudioCapability* pCapability);
++int audioPlayerGetCapability(const AudioPlayerHandle handle, AudioCapability* pCapability);
+ 
+ /**
+  * @brief Set player format, channel number, bit depth and sample rate.
+@@ -80,7 +80,7 @@ int audioPlayerSetFormat(AudioPlayerHandle handle, const AudioFormat format, con
+  * @param[in] pBitDepth Frame bit depth.
+  * @return int 0 or error code.
+  */
+-int audioPlayerGetFormat(const AudioPlayerHandle const handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
++int audioPlayerGetFormat(const AudioPlayerHandle handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
+                          AudioBitDepth* pBitDepth);
+ 
+ /**
+diff --git a/source/FILE/FILEAudioCapturer.c b/source/FILE/FILEAudioCapturer.c
+index 8fb3e69..17d4ca2 100644
+--- a/source/FILE/FILEAudioCapturer.c
++++ b/source/FILE/FILEAudioCapturer.c
+@@ -84,7 +84,7 @@ AudioCapturerHandle audioCapturerCreate(void)
+     return (AudioCapturerHandle) fileHandle;
+ }
+ 
+-AudioCapturerStatus audioCapturerGetStatus(const AudioCapturerHandle const handle)
++AudioCapturerStatus audioCapturerGetStatus(const AudioCapturerHandle handle)
+ {
+     if (!handle) {
+         return AUD_CAP_STATUS_NOT_READY;
+@@ -94,7 +94,7 @@ AudioCapturerStatus audioCapturerGetStatus(const AudioCapturerHandle const handl
+     return fileHandle->status;
+ }
+ 
+-int audioCapturerGetCapability(const AudioCapturerHandle const handle, AudioCapability* pCapability)
++int audioCapturerGetCapability(const AudioCapturerHandle handle, AudioCapability* pCapability)
+ {
+     FILE_HANDLE_NULL_CHECK(handle);
+     FILE_HANDLE_GET(handle);
+@@ -170,7 +170,7 @@ int audioCapturerSetFormat(AudioCapturerHandle handle, const AudioFormat format,
+     return 0;
+ }
+ 
+-int audioCapturerGetFormat(const AudioCapturerHandle const handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
++int audioCapturerGetFormat(const AudioCapturerHandle handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
+                            AudioBitDepth* pBitDepth)
+ {
+     FILE_HANDLE_NULL_CHECK(handle);
+diff --git a/source/FILE/FILEAudioPlayer.c b/source/FILE/FILEAudioPlayer.c
+index 8f35381..2f18b77 100644
+--- a/source/FILE/FILEAudioPlayer.c
++++ b/source/FILE/FILEAudioPlayer.c
+@@ -33,12 +33,12 @@ AudioPlayerHandle audioPlayerCreate(void)
+     return NULL;
+ }
+ 
+-AudioPlayerStatus audioPlayerGetStatus(const AudioPlayerHandle const handle)
++AudioPlayerStatus audioPlayerGetStatus(const AudioPlayerHandle handle)
+ {
+     return AUD_PLY_STATUS_NOT_READY;
+ }
+ 
+-int audioPlayerGetCapability(const AudioPlayerHandle const handle, AudioCapability* pCapability)
++int audioPlayerGetCapability(const AudioPlayerHandle handle, AudioCapability* pCapability)
+ {
+     return -EAGAIN;
+ }
+@@ -49,7 +49,7 @@ int audioPlayerSetFormat(AudioPlayerHandle handle, const AudioFormat format, con
+     return -EAGAIN;
+ }
+ 
+-int audioPlayerGetFormat(const AudioPlayerHandle const handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
++int audioPlayerGetFormat(const AudioPlayerHandle handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
+                          AudioBitDepth* pBitDepth)
+ {
+     return -EAGAIN;
+diff --git a/source/FILE/FILEVideoCapturer.c b/source/FILE/FILEVideoCapturer.c
+index 4054bb2..018c548 100644
+--- a/source/FILE/FILEVideoCapturer.c
++++ b/source/FILE/FILEVideoCapturer.c
+@@ -74,7 +74,7 @@ VideoCapturerHandle videoCapturerCreate(void)
+     return (VideoCapturerHandle) fileHandle;
+ }
+ 
+-VideoCapturerStatus videoCapturerGetStatus(const VideoCapturerHandle const handle)
++VideoCapturerStatus videoCapturerGetStatus(const VideoCapturerHandle handle)
+ {
+     if (!handle) {
+         return VID_CAP_STATUS_NOT_READY;
+@@ -84,7 +84,7 @@ VideoCapturerStatus videoCapturerGetStatus(const VideoCapturerHandle const handl
+     return fileHandle->status;
+ }
+ 
+-int videoCapturerGetCapability(const VideoCapturerHandle const handle, VideoCapability* pCapability)
++int videoCapturerGetCapability(const VideoCapturerHandle handle, VideoCapability* pCapability)
+ {
+     FILE_HANDLE_NULL_CHECK(handle);
+     FILE_HANDLE_GET(handle);
+@@ -132,7 +132,7 @@ int videoCapturerSetFormat(VideoCapturerHandle handle, const VideoFormat format,
+     return 0;
+ }
+ 
+-int videoCapturerGetFormat(const VideoCapturerHandle const handle, VideoFormat* pFormat, VideoResolution* pResolution)
++int videoCapturerGetFormat(const VideoCapturerHandle handle, VideoFormat* pFormat, VideoResolution* pResolution)
+ {
+     FILE_HANDLE_NULL_CHECK(handle);
+     FILE_HANDLE_GET(handle);

--- a/samples/kvsapp/kvsappcli.c
+++ b/samples/kvsapp/kvsappcli.c
@@ -220,7 +220,7 @@ static void *audioThread(void *arg)
         }
     }
 
-    audioCapturerReleaseStream(videoCapturerHandle);
+    audioCapturerReleaseStream(audioCapturerHandle);
     printf("audio thread leaving, err:%d\n", res);
 
     return NULL;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,8 @@ set(CMAKE_C_FLAGS "-D_XOPEN_SOURCE=600 -D_POSIX_C_SOURCE=200112L ${CMAKE_C_FLAGS
 
 set(LIB_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
+option(ENABLE_MKV_DUMP "Enable MKV dump to file" OFF)
+
 set(LIB_SRC
     ${LIB_DIR}/include/kvs/kvsapp.h
     ${LIB_DIR}/include/kvs/kvsapp_options.h
@@ -96,6 +98,11 @@ target_include_directories(${LIB_NAME} PRIVATE ${LIB_PRV_INC})
 if(${USE_WEBRTC_MBEDTLS_LIB})
     target_link_directories(${LIB_NAME} PUBLIC ${WEBRTC_LIB_PATH})
     target_include_directories(${LIB_NAME} PUBLIC ${WEBRTC_INC_PATH})
+endif()
+
+if(${ENABLE_MKV_DUMP})
+    message(STATUS "MKV dump enabled")
+    target_compile_definitions(${LIB_NAME} PUBLIC ENABLE_MKV_DUMP)
 endif()
 
 target_link_libraries(${LIB_NAME} PUBLIC

--- a/src/include/kvs/mkv_generator.h
+++ b/src/include/kvs/mkv_generator.h
@@ -38,6 +38,23 @@
 
 #define MKV_TRACK_SIZE          ( 2 )
 
+#define MAX_TAG_AMOUNT      10
+#define MAX_TAG_NAME_LEN    128
+#define MAX_TAG_VALUE_LEN   256
+
+//https://github.com/awslabs/amazon-kinesis-video-streams-pic/blob/c98c2a256a7bb3dfc4db41ae26d45e28ac7eec56/src/mkvgen/include/com/amazonaws/kinesis/video/mkvgen/Include.h#L99
+//https://github.com/awslabs/amazon-kinesis-video-streams-pic/blob/c98c2a256a7bb3dfc4db41ae26d45e28ac7eec56/src/mkvgen/include/com/amazonaws/kinesis/video/mkvgen/Include.h#L104C31-L104C34
+
+typedef struct {
+    char key[MAX_TAG_NAME_LEN];
+    char value[MAX_TAG_VALUE_LEN];
+} MkvTag_t;
+
+typedef struct {
+    uint8_t* buffer;
+    size_t size;
+} MkvTagsBuffer_t;
+
 typedef enum TrackType
 {
     TRACK_VIDEO = 1,
@@ -212,5 +229,17 @@ int Mkv_generateAacCodecPrivateData(Mpeg4AudioObjectTypes_t objectType, uint32_t
  * @return 0 on success, non-zero value otherwise
  */
 int Mkv_generatePcmCodecPrivateData(PcmFormatCode_t format, uint32_t uSamplingRate, uint16_t channels, uint8_t **ppCodecPrivateData, size_t *puCodecPrivateDataLen);
+
+/**
+ * @brief Allocates and writes MKV tags with their headers to the buffer. The caller is responsible for freeing out->buffer using free().
+ *
+ * @param tagsList[in] the tags to write
+ * @param tagsListLen[in] length of tagsList
+ * @param out[out] buffer containing the bytes written and its length
+ * @return 0 on success, non-zero value otherwise
+ *
+ * @see MkvTag_t  https://www.matroska.org/technical/elements.html
+ */
+int Mkv_generateTags(const MkvTag_t tagsList[], size_t tagsListLen, MkvTagsBuffer_t* out);
 
 #endif /* KVS_MKV_GENERATOR_H */

--- a/src/include/kvs/stream.h
+++ b/src/include/kvs/stream.h
@@ -133,6 +133,21 @@ int Kvs_streamMemStatTotal(StreamHandle xStreamHandle, size_t *puMemTotal);
 int Kvs_dataFrameGetContent(DataFrameHandle xDataFrameHandle, uint8_t **ppMkvHeader, size_t *puMkvHeaderLen, uint8_t **ppData, size_t *puDataLen);
 
 /**
+ * @brief Add MKV tags to the data frame
+ *
+ * @param xDataFrameHandle[in] The data frame handle
+ * @param tagsList[in] List of tags to add to this data frame
+ * @param tagsListLen[in] Length of the tagsList
+ * @param endOfStream[in] Whether to add the end of fragment tag (EOFR)
+ * @param ppMkvHeader[out] The MKV header
+ * @param puMkvHeaderLen[out] THe MKV header length
+ * @param ppData[out] The data pointer
+ * @param puDataLen[out] The data length
+ * @return 0 on success, non-zero value otherwise
+ */
+int Kvs_dataFrameAddTags(DataFrameHandle xDataFrameHandle, MkvTag_t* tagsList, size_t tagsListLen, bool endOfStream, uint8_t **ppMkvHeader, size_t *puMkvHeaderLen, uint8_t **ppData, size_t *puDataLen);
+
+/**
  * @brief Terminate a data frame handle
  *
  * @param xDataFrameHandle[in] The data frame handle

--- a/src/source/app/kvsapp.c
+++ b/src/source/app/kvsapp.c
@@ -114,6 +114,9 @@ typedef struct KvsApp
     bool isAudioTrackPresent;
     AudioTrackInfo_t *pAudioTrackInfo;
 
+    MkvTag_t* tagsList;
+    size_t tagsListLen;
+
     /* Session scope callbacks */
     OnMkvSentCallbackInfo_t onMkvSentCallbackInfo;
 } KvsApp_t;
@@ -780,7 +783,13 @@ static int prvPutMediaSendData(KvsApp_t *pKvs, int *pxSendCnt, bool bForceSend)
             LogError("Failed to get data and mkv header to send");
             /* Propagate the res error */
         }
-        else if ((res = Kvs_putMediaUpdate(pKvs->xPutMediaHandle, pMkvHeader, uMkvHeaderLen, pData, uDataLen)) != KVS_ERRNO_NONE)
+        else if (
+            (((DataFrameIn_t *)xDataFrameHandle)->xClusterType == MKV_CLUSTER) && pKvs->tagsListLen > 0 &&
+            (res = Kvs_dataFrameAddTags(xDataFrameHandle, pKvs->tagsList, pKvs->tagsListLen, false, &pMkvHeader, &uMkvHeaderLen, &pData, &uDataLen)) != KVS_ERRNO_NONE) {
+            LogError("Failed to add tags");
+            /* Propagate the res error */
+        }
+        else if (Kvs_putMediaUpdate(pKvs->xPutMediaHandle, pMkvHeader, uMkvHeaderLen, pData, uDataLen) != KVS_ERRNO_NONE)
         {
             LogError("Failed to update");
             /* Propagate the res error */
@@ -893,6 +902,26 @@ static int prvPutMediaDoWorkSendEndOfFrames(KvsApp_t *pKvs)
     return res;
 }
 
+static int setupTagsForSession(KvsApp_t *pKvs)
+{
+    int res = KVS_ERRNO_NONE;
+    const size_t tagsListLen = MAX_TAG_AMOUNT - 1; // Note: end of fragment tag counts towards the 10 limit
+    MkvTag_t *tags = kvsMalloc(tagsListLen * sizeof(MkvTag_t));
+
+    for (int i = 1; i <= tagsListLen; i++)
+    {
+        snprintf((char *)tags[i - 1].key, MAX_TAG_NAME_LEN, "test_key_%d", i);
+        snprintf((char *)tags[i - 1].value, MAX_TAG_VALUE_LEN, "test_value_%d", i);
+    }
+
+    pKvs->tagsList = tags;
+    pKvs->tagsListLen = tagsListLen;
+
+    LogInfo("Setup tags for session");
+
+    return res;
+}
+
 KvsAppHandle KvsApp_create(const char *pcHost, const char *pcRegion, const char *pcService, const char *pcStreamName)
 {
     int res = KVS_ERRNO_NONE;
@@ -950,6 +979,8 @@ KvsAppHandle KvsApp_create(const char *pcHost, const char *pcRegion, const char 
             pKvs->pVideoTrackInfo = NULL;
             pKvs->isAudioTrackPresent = false;
             pKvs->pAudioTrackInfo = NULL;
+
+            setupTagsForSession(pKvs);
         }
     }
 

--- a/src/source/app/kvsapp.c
+++ b/src/source/app/kvsapp.c
@@ -1093,6 +1093,11 @@ void KvsApp_terminate(KvsAppHandle handle)
             kvsFree(pKvs->pPps);
             pKvs->pPps = NULL;
         }
+        if (pKvs->tagsList != NULL)
+        {
+            kvsFree(pKvs->tagsList);
+            pKvs->tagsList = NULL;
+        }
 
         Unlock(pKvs->xLock);
 

--- a/src/source/app/kvsapp.c
+++ b/src/source/app/kvsapp.c
@@ -907,17 +907,24 @@ static int setupTagsForSession(KvsApp_t *pKvs)
     int res = KVS_ERRNO_NONE;
     const size_t tagsListLen = MAX_TAG_AMOUNT - 1; // Note: end of fragment tag counts towards the 10 limit
     MkvTag_t *tags = kvsMalloc(tagsListLen * sizeof(MkvTag_t));
-
-    for (int i = 1; i <= tagsListLen; i++)
+    if (tags == NULL)
     {
-        snprintf((char *)tags[i - 1].key, MAX_TAG_NAME_LEN, "test_key_%d", i);
-        snprintf((char *)tags[i - 1].value, MAX_TAG_VALUE_LEN, "test_value_%d", i);
+        res = KVS_ERROR_OUT_OF_MEMORY;
+        LogError("OOM: tagsList");
     }
+    else
+    {
+        for (int i = 1; i <= tagsListLen; i++)
+        {
+            snprintf((char *)tags[i - 1].key, MAX_TAG_NAME_LEN, "test_key_%d", i);
+            snprintf((char *)tags[i - 1].value, MAX_TAG_VALUE_LEN, "test_value_%d", i);
+        }
 
-    pKvs->tagsList = tags;
-    pKvs->tagsListLen = tagsListLen;
+        pKvs->tagsList = tags;
+        pKvs->tagsListLen = tagsListLen;
 
-    LogInfo("Setup tags for session");
+        LogInfo("Setup tags for session");
+    }
 
     return res;
 }
@@ -980,7 +987,11 @@ KvsAppHandle KvsApp_create(const char *pcHost, const char *pcRegion, const char 
             pKvs->isAudioTrackPresent = false;
             pKvs->pAudioTrackInfo = NULL;
 
-            setupTagsForSession(pKvs);
+            if ((res = setupTagsForSession(pKvs)) != KVS_ERRNO_NONE)
+            {
+                LogError("Failed to setup tags");
+                /* Propagate the res error */
+            }
         }
     }
 

--- a/src/source/mkv/mkv_generator.c
+++ b/src/source/mkv/mkv_generator.c
@@ -1021,6 +1021,12 @@ int Mkv_generateTags(const MkvTag_t tagsList[], const size_t tagsListLen, MkvTag
         return KVS_ERROR_INVALID_ARGUMENT;
     }
 
+    if (tagsListLen > MAX_TAG_AMOUNT)
+    {
+        LogError("Adding too many tags. Adding: %zu, Max: %d", tagsListLen, MAX_TAG_AMOUNT);
+        return KVS_ERROR_INVALID_ARGUMENT;
+    }
+
     out->buffer = NULL;
     out->size = 0;
 

--- a/src/source/stream/stream.c
+++ b/src/source/stream/stream.c
@@ -476,7 +476,7 @@ int Kvs_dataFrameAddTags(DataFrameHandle xDataFrameHandle, MkvTag_t* tagsList, s
 
     size_t effectiveTagsLen = tagsListLen + (endOfStream ? 1 : 0);
     if (effectiveTagsLen >= MAX_TAG_AMOUNT) {
-        LogError("Trying to add too many tags");
+        LogError("Trying to add too many tags - Adding: %zu tags, Max: %d", effectiveTagsLen, MAX_TAG_AMOUNT);
         return KVS_ERROR_INVALID_ARGUMENT;
     }
 


### PR DESCRIPTION
*Issue #, if available:*
- Resolves #87
- Continuation of #89

*Description of changes:*
- Add fragment metadata to the `kvsappcli` application.
  - Add the metadata that should be added for every fragment to `KvsApp` struct.
- Optimization: Reduce the size fields for the tag headers, since there is are length restrictions for tags in KVS https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/limits.html#limits-streaming-metadata, 8 bytes for each is not necessary.
- Fix build and runtime issues with `kvsappcli` application so it builds out of the box for Mac.
- Add CI to build and run `kvsappcli` for a short time, verify clean exit, and verify fragment metadata was added.
- Add mkv dump featury for debugging parity. https://github.com/awslabs/amazon-kinesis-video-streams-producer-c/blob/5fb356e484d734ce3650c751a4469985c488bc1f/src/source/Response.c#L38-L46. It will save the MKV it would have sent to KVS to the file.
- Print out the endpoint that it tries to control plane endpoint it connects to (in case AWS_KVS_HOST is not set, region mismatch)
- Print out the stream name it tries to use

### Build issues addressed
1. Add a patch to address `const` compile issue in media interface

### Runtime issues addressed
1. Fix a segfault during cleanup path due to double-free caused by the wrong thread id being shutdown (video thread twice).
2. Fix occasional segfault due to string out of bounds issue in fragment ack parser.

I encountered one additional issue where when building for Release, it won't connect due to SSL verification error. The current workaround I'm using is to build with Debug. I observed disabling the compiler optimizations works as well, though not ideal.
```
set(CMAKE_C_FLAGS_RELEASE "-O0")  # Disable optimization in Release mode
```

*Testing*
- New Github actions CI (automatic)
- Ran CLI application (manually) on Mac
- Manually checked tags are there with GetMedia and with local mkv dump
- Ran on AMB82-Mini and checked playback in KVS console. I'll look into adding instructions for that in the future seeing #86.

<img width="696" alt="image" src="https://github.com/user-attachments/assets/d10c702d-7ef6-4a0c-8f95-ef382e4f5466" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
