### PR TITLE
Only call createStream on 404

### DIFF
--- a/samples/kvs-amebapro/kvs_producer.c
+++ b/samples/kvs-amebapro/kvs_producer.c
@@ -631,10 +631,17 @@ static int setupDataEndpoint(Kvs_t *pKvs)
             if (Kvs_describeStream(&(pKvs->xServicePara), &(pKvs->xDescPara), &uHttpStatusCode) != 0 || uHttpStatusCode != 200)
             {
                 printf("Failed to describe stream\r\n");
-                printf("Try to create stream\r\n");
-                if (Kvs_createStream(&(pKvs->xServicePara), &(pKvs->xCreatePara), &uHttpStatusCode) != 0 || uHttpStatusCode != 200)
+                if (uHttpStatusCode == 404)
                 {
-                    printf("Failed to create stream\r\n");
+                    printf("Try to create stream\r\n");
+                    if (Kvs_createStream(&(pKvs->xServicePara), &(pKvs->xCreatePara), &uHttpStatusCode) != 0 || uHttpStatusCode != 200)
+                    {
+                        printf("Failed to create stream\r\n");
+                        res = ERRNO_FAIL;
+                    }
+                }
+                else
+                {
                     res = ERRNO_FAIL;
                 }
             }

--- a/src/source/app/kvsapp.c
+++ b/src/source/app/kvsapp.c
@@ -546,16 +546,23 @@ static int setupDataEndpoint(KvsApp_t *pKvs)
                 LogInfo("Failed to describe stream, status code:%u", uHttpStatusCode);
                 res = KVS_GENERATE_RESTFUL_ERROR(uHttpStatusCode);
 
-                LogInfo("Try to create stream");
-                if ((res = Kvs_createStream(&(pKvs->xServicePara), &(pKvs->xCreatePara), &uHttpStatusCode)) != KVS_ERRNO_NONE)
+                if (uHttpStatusCode != 404)
                 {
-                    LogError("Unable to create stream");
                     /* Propagate the res error */
                 }
-                else if (uHttpStatusCode != 200)
+                else
                 {
-                    LogInfo("Failed to create stream, status code:%u", uHttpStatusCode);
-                    res = KVS_GENERATE_RESTFUL_ERROR(uHttpStatusCode);
+                    LogInfo("Try to create stream");
+                    if ((res = Kvs_createStream(&(pKvs->xServicePara), &(pKvs->xCreatePara), &uHttpStatusCode)) != KVS_ERRNO_NONE)
+                    {
+                        LogError("Unable to create stream");
+                        /* Propagate the res error */
+                    }
+                    else if (uHttpStatusCode != 200)
+                    {
+                        LogInfo("Failed to create stream, status code:%u", uHttpStatusCode);
+                        res = KVS_GENERATE_RESTFUL_ERROR(uHttpStatusCode);
+                    }
                 }
             }
 


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*Description of changes:*

This PR improves error handling in the KVS stream setup process, specifically, the [endpoint discovery pattern implementation](https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/how-it-works-kinesis-video-api-producer-sdk.html#how-it-works-api-pattern) by only attempting to create a stream when receiving a 404 (Not Found) status code from the describe stream operation.

-  **kvs_producer.c and kvsapp**: Modified setupDataEndpoint() to check if the HTTP status code is 404 before attempting to create a stream. If the status code is not 404, the function now fails immediately instead of trying to create a stream.

Note: Creating a stream that already exists will result in the ResourceIinUseException 400 being returned from the service, hence the `setupDataEndpoint` function would still return an error to the application in the previous implementation. The new implementation propagates the DescribeStream error in the non-404 case instead of always propagating the CreateStream error.

*Rationale:*

- Previously, the code would attempt to create a stream whenever the describe stream operation failed, regardless of the failure reason. This could lead to unnecessary API calls and potential issues when the failure was due to reasons other than the stream not existing (e.g., permission errors, network issues, throttling, etc.). 
- With this change, stream creation is only attempted when we receive a 404 http code, which specifically indicates that the stream doesn't exist and creation is the appropriate next step.

*Testing:*

Ran the kvsappcli locally on Mac to confirm the adjusted behavior. 

<details><summary>Before</summary>

```
./bin/kvsappcli demo-stream
Info: Setup tags for session
AudioCapturer new status[1]
VideoCapturer new status[1]
AudioCapturer new status[2]
Info: Try to describe stream
VideoCapturer new status[2]
Info: Making describe request to: kinesisvideo.us-west-2.amazonaws.com
Info: Stream name: demo-stream
Info: SPS is found
Info: SPS is set
Info: PPS is found
Info: PPS is set
Info: KVS stream buffer created
Info: Describe Stream failed, HTTP status code: 403
Info: HTTP response message:{"message":"The security token included in the request is invalid."}
Info: Failed to describe stream, status code:403
Info: Try to create stream
Info: Create Stream failed, HTTP status code: 403
Info: HTTP response message:{"message":"The security token included in the request is invalid."}
Info: Failed to create stream, status code:403
Error: Time:Wed Nov 19 10:09:11 2025 File:/Users/me/Downloads/amazon-kinesis-video-streams-producer-embedded-c/src/source/app/kvsapp.c Func:KvsApp_open Line:1369 Failed to setup data endpoint
Failed to open KVS app, err:-10193
AudioCapturer new status[1]
audio thread leaving, err:0
VideoCapturer new status[1]
video thread leaving, err:0
VideoCapturer new status[0]
AudioCapturer new status[0]
```

</details>
<details><summary>After</summary>

```
./bin/kvsappcli demo-stream
Info: Setup tags for session
AudioCapturer new status[1]
VideoCapturer new status[1]
AudioCapturer new status[2]
Info: Try to describe stream
VideoCapturer new status[2]
Info: Making describe request to: kinesisvideo.us-west-2.amazonaws.com
Info: Stream name: demo-stream
Info: SPS is found
Info: SPS is set
Info: PPS is found
Info: PPS is set
Info: KVS stream buffer created
Info: Describe Stream failed, HTTP status code: 403
Info: HTTP response message:{"message":"The security token included in the request is invalid."}
Info: Failed to describe stream, status code:403
Error: Time:Wed Nov 19 10:08:39 2025 File:/Users/me/Downloads/amazon-kinesis-video-streams-producer-embedded-c/src/source/app/kvsapp.c Func:KvsApp_open Line:1376 Failed to setup data endpoint
Failed to open KVS app, err:-10193
VideoCapturer new status[1]
video thread leaving, err:0
AudioCapturer new status[1]
audio thread leaving, err:0
VideoCapturer new status[0]
AudioCapturer new status[0]
```

</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
